### PR TITLE
Use rect/theme helpers for control drawing

### DIFF
--- a/commctl/button.c
+++ b/commctl/button.c
@@ -4,6 +4,8 @@
 #include "../user/user.h"
 #include "../user/messages.h"
 #include "../user/draw.h"
+#include "../user/rect.h"
+#include "../user/theme.h"
 #include "commctl.h"
 
 // Helper function (will be moved to ui/user/window.c later)
@@ -45,15 +47,14 @@ result_t win_button(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) 
       // When the button has keyboard focus kColorFocusRing takes precedence.
       uint32_t bg = (_focused == win) ? get_sys_color(kColorFocusRing) :
                     (win->flags & BUTTON_DEFAULT) ? 0xff000000 : get_sys_color(kColorWindowBg);
-      fill_rect(bg, win->frame.x-1, win->frame.y-1, win->frame.w+2, win->frame.h+2);
+      rect_t outer = rect_inset(win->frame, -1);
+      fill_rect(bg, outer.x, outer.y, outer.w, outer.h);
       draw_button(&win->frame, 1, 1, show_pressed);
-      int tx = win->frame.x + (win->frame.w - strwidth(win->title)) / 2;
-      int ty = win->frame.y + (win->frame.h - CHAR_HEIGHT) / 2;
-      int px = show_pressed ? 1 : 0;
-      if (!show_pressed) {
-        draw_text_small(win->title, tx + 1, ty + 1, get_sys_color(kColorDarkEdge));
-      }
-      draw_text_small(win->title, tx + px, ty + px, get_sys_color(kColorTextNormal));
+      rect_t label = rect_center(win->frame, strwidth(win->title), CHAR_HEIGHT);
+      if (!show_pressed)
+        draw_text_small(win->title, label.x + TEXT_SHADOW_OFFSET, label.y + TEXT_SHADOW_OFFSET, get_sys_color(kColorDarkEdge));
+      rect_t label_draw = rect_offset(label, show_pressed ? 1 : 0, show_pressed ? 1 : 0);
+      draw_text_small(win->title, label_draw.x, label_draw.y, get_sys_color(kColorTextNormal));
       return true;
     }
     case kWindowMessageLeftButtonDown:
@@ -130,8 +131,9 @@ result_t win_toolbar_button(window_t *win, uint32_t msg, uint32_t wparam, void *
     case kWindowMessagePaint: {
       bool show_pressed = win->pressed ||
                           ((win->flags & BUTTON_PUSHLIKE) && win->value);
+      rect_t focus_outer = rect_inset(win->frame, -2);
       fill_rect(_focused == win ? get_sys_color(kColorFocusRing) : get_sys_color(kColorWindowBg),
-                win->frame.x-2, win->frame.y-2, win->frame.w+4, win->frame.h+4);
+                focus_outer.x, focus_outer.y, focus_outer.w, focus_outer.h);
       draw_button(&win->frame, 1, 1, show_pressed);
       int px = show_pressed ? 1 : 0;
       toolbar_button_data_t *bd = (toolbar_button_data_t *)win->userdata;
@@ -144,18 +146,16 @@ result_t win_toolbar_button(window_t *win, uint32_t msg, uint32_t wparam, void *
         float v0 = (float)(row * s->icon_h) / (float)s->sheet_h;
         float u1 = u0 + (float)s->icon_w / (float)s->sheet_w;
         float v1 = v0 + (float)s->icon_h / (float)s->sheet_h;
-        int ix = win->frame.x + (win->frame.w - s->icon_w) / 2 + px;
-        int iy = win->frame.y + (win->frame.h - s->icon_h) / 2 + px;
-        draw_sprite_region((int)s->tex, ix, iy, s->icon_w, s->icon_h,
+        rect_t icon = rect_offset(rect_center(win->frame, s->icon_w, s->icon_h), px, px);
+        draw_sprite_region((int)s->tex, icon.x, icon.y, s->icon_w, s->icon_h,
                            u0, v0, u1, v1, 1.0f);
       } else {
         // Fallback: draw text label when no image has been set.
+        rect_t inner = rect_inset(win->frame, BUTTON_TEXT_INSET);
         if (!show_pressed)
-          draw_text_small(win->title, win->frame.x+4, win->frame.y+4, get_sys_color(kColorDarkEdge));
-        draw_text_small(win->title,
-                        win->frame.x + (show_pressed ? 4 : 3),
-                        win->frame.y + (show_pressed ? 4 : 3),
-                        get_sys_color(kColorTextNormal));
+          draw_text_small(win->title, inner.x + TEXT_SHADOW_OFFSET, inner.y + TEXT_SHADOW_OFFSET, get_sys_color(kColorDarkEdge));
+        rect_t inner_draw = rect_offset(inner, px, px);
+        draw_text_small(win->title, inner_draw.x, inner_draw.y, get_sys_color(kColorTextNormal));
       }
       return true;
     }

--- a/commctl/checkbox.c
+++ b/commctl/checkbox.c
@@ -4,6 +4,8 @@
 #include "../user/user.h"
 #include "../user/messages.h"
 #include "../user/draw.h"
+#include "../user/rect.h"
+#include "../user/theme.h"
 
 // Helper function (will be moved to ui/user/window.c later)
 extern window_t *get_root_window(window_t *window);
@@ -16,15 +18,24 @@ result_t win_checkbox(window_t *win, uint32_t msg, uint32_t wparam, void *lparam
       win->frame.w = MAX(win->frame.w, strwidth(win->title)+16);
       win->frame.h = MAX(win->frame.h, BUTTON_HEIGHT);
       return true;
-    case kWindowMessagePaint:
-      fill_rect(_focused == win?get_sys_color(kColorFocusRing):get_sys_color(kColorWindowBg), win->frame.x-2, win->frame.y-2, 14, 14);
-      draw_button(MAKERECT(win->frame.x, win->frame.y, 10, 10), 1, 1, win->pressed);
-      draw_text_small(win->title, win->frame.x + 17, win->frame.y + 3, get_sys_color(kColorDarkEdge));
-      draw_text_small(win->title, win->frame.x + 16, win->frame.y + 2, get_sys_color(kColorTextNormal));
+    case kWindowMessagePaint: {
+      rect_t rem = win->frame;
+      rect_t box = rect_split_left(&rem, CHECKBOX_BOX_SIZE);
+      box.h = CHECKBOX_BOX_SIZE;
+      rect_t focus_bg = rect_inset(box, -CHECKBOX_FOCUS_PAD);
+      fill_rect(_focused == win ? get_sys_color(kColorFocusRing) : get_sys_color(kColorWindowBg),
+                focus_bg.x, focus_bg.y, focus_bg.w, focus_bg.h);
+      draw_button(&box, 1, 1, win->pressed);
+      int lx = rem.x + CHECKBOX_GAP;
+      int ly = win->frame.y + CHECKBOX_TEXT_Y;
+      draw_text_small(win->title, lx + TEXT_SHADOW_OFFSET, ly + TEXT_SHADOW_OFFSET, get_sys_color(kColorDarkEdge));
+      draw_text_small(win->title, lx, ly, get_sys_color(kColorTextNormal));
       if (win->value) {
-        draw_icon8(icon8_checkbox, win->frame.x+1, win->frame.y+1, get_sys_color(kColorTextNormal));
+        rect_t checkmark = rect_offset(box, TEXT_SHADOW_OFFSET, TEXT_SHADOW_OFFSET);
+        draw_icon8(icon8_checkbox, checkmark.x, checkmark.y, get_sys_color(kColorTextNormal));
       }
       return true;
+    }
     case kWindowMessageLeftButtonDown:
       win->pressed = true;
       invalidate_window(win);

--- a/commctl/label.c
+++ b/commctl/label.c
@@ -5,8 +5,8 @@
 #include "../user/user.h"
 #include "../user/messages.h"
 #include "../user/draw.h"
-
-#define PADDING 3
+#include "../user/rect.h"
+#include "../user/theme.h"
 
 // Helper function (will be moved to ui/user/window.c later)
 extern window_t *_focused;
@@ -33,8 +33,9 @@ result_t win_label(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
         col = get_sys_color((sys_color_idx_t)ud);
       else
         col = (uint32_t)ud;
-      draw_text_small(win->title, win->frame.x+1, win->frame.y+1+PADDING, get_sys_color(kColorDarkEdge));
-      draw_text_small(win->title, win->frame.x, win->frame.y+PADDING, col);
+      rect_t text_pos = rect_offset(win->frame, 0, LABEL_TEXT_PADDING);
+      draw_text_small(win->title, text_pos.x + TEXT_SHADOW_OFFSET, text_pos.y + TEXT_SHADOW_OFFSET, get_sys_color(kColorDarkEdge));
+      draw_text_small(win->title, text_pos.x, text_pos.y, col);
       return true;
     }
   }

--- a/commctl/list.c
+++ b/commctl/list.c
@@ -5,6 +5,7 @@
 #include "../user/user.h"
 #include "../user/messages.h"
 #include "../user/draw.h"
+#include "../user/rect.h"
 
 #define LIST_HEIGHT     13
 #define LIST_X          3
@@ -39,11 +40,13 @@ result_t win_list(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
       return true;
     case kWindowMessagePaint:
       for (uint32_t i = 0; i < cb->cursor_pos; i++) {
+        rect_t item = { 0, (int)(i * LIST_HEIGHT), win->frame.w, LIST_HEIGHT };
+        rect_t text_pos = rect_inset_xy(item, LIST_X, LIST_Y);
         if (i == win->cursor_pos) {
-          fill_rect(get_sys_color(kColorTextNormal), 0, i*LIST_HEIGHT, win->frame.w, LIST_HEIGHT);
-          draw_text_small(texts[i], LIST_X, i*LIST_HEIGHT+LIST_Y, get_sys_color(kColorWindowBg));
+          fill_rect(get_sys_color(kColorTextNormal), item.x, item.y, item.w, item.h);
+          draw_text_small(texts[i], text_pos.x, text_pos.y, get_sys_color(kColorWindowBg));
         } else {
-          draw_text_small(texts[i], LIST_X, i*LIST_HEIGHT+LIST_Y, get_sys_color(kColorTextNormal));
+          draw_text_small(texts[i], text_pos.x, text_pos.y, get_sys_color(kColorTextNormal));
         }
       }
       return true;

--- a/ui.h
+++ b/ui.h
@@ -8,6 +8,8 @@
 #include "user/messages.h"
 #include "user/text.h"
 #include "user/draw.h"
+#include "user/rect.h"
+#include "user/theme.h"
 #include "user/accel.h"
 #include "user/image.h"
 

--- a/user/rect.h
+++ b/user/rect.h
@@ -1,0 +1,73 @@
+#ifndef __UI_RECT_H__
+#define __UI_RECT_H__
+
+// rect_t layout helpers — analogous to WinAPI InflateRect / OffsetRect /
+// IntersectRect, but oriented around the split-and-slice idiom used by
+// toolbar and widget layout code.
+//
+// All helpers work on value copies unless the function signature takes
+// rect_t * (the split variants, which shrink the remainder in place).
+
+#include "user.h"
+
+// ── Inflation / deflation ─────────────────────────────────────────────────
+
+// Shrink all four sides by d (negative d expands).
+static inline rect_t rect_inset(rect_t r, int d) {
+  return (rect_t){ r.x + d, r.y + d, r.w - 2*d, r.h - 2*d };
+}
+
+// Shrink horizontal sides by dx and vertical sides by dy independently.
+static inline rect_t rect_inset_xy(rect_t r, int dx, int dy) {
+  return (rect_t){ r.x + dx, r.y + dy, r.w - 2*dx, r.h - 2*dy };
+}
+
+// ── Translation ───────────────────────────────────────────────────────────
+
+// Translate without changing size.
+static inline rect_t rect_offset(rect_t r, int dx, int dy) {
+  return (rect_t){ r.x + dx, r.y + dy, r.w, r.h };
+}
+
+// ── Centering ─────────────────────────────────────────────────────────────
+
+// Return a rect of given size centered inside r.
+static inline rect_t rect_center(rect_t r, int w, int h) {
+  return (rect_t){ r.x + (r.w - w) / 2, r.y + (r.h - h) / 2, w, h };
+}
+
+// ── Edge splits (shrink remainder in place) ───────────────────────────────
+
+// Slice a strip of width w off the left edge of *r.
+// Returns the sliced strip; *r is updated to the remaining area.
+static inline rect_t rect_split_left(rect_t *r, int w) {
+  rect_t left = { r->x, r->y, w, r->h };
+  r->x += w;
+  r->w -= w;
+  return left;
+}
+
+// Slice a strip of height h off the top edge of *r.
+// Returns the sliced strip; *r is updated to the remaining area.
+static inline rect_t rect_split_top(rect_t *r, int h) {
+  rect_t top = { r->x, r->y, r->w, h };
+  r->y += h;
+  r->h -= h;
+  return top;
+}
+
+// Slice a strip of width w off the right edge of *r.
+// Returns the sliced strip; *r is updated to the remaining area.
+static inline rect_t rect_split_right(rect_t *r, int w) {
+  r->w -= w;
+  return (rect_t){ r->x + r->w, r->y, w, r->h };
+}
+
+// Slice a strip of height h off the bottom edge of *r.
+// Returns the sliced strip; *r is updated to the remaining area.
+static inline rect_t rect_split_bottom(rect_t *r, int h) {
+  r->h -= h;
+  return (rect_t){ r->x, r->y + r->h, r->w, h };
+}
+
+#endif /* __UI_RECT_H__ */

--- a/user/theme.h
+++ b/user/theme.h
@@ -1,0 +1,46 @@
+#ifndef __UI_THEME_H__
+#define __UI_THEME_H__
+
+// Named spacing and geometry constants for widget draw code.
+// Dimension constants that are owned by a specific subsystem (e.g.
+// SCROLLBAR_WIDTH, TITLEBAR_HEIGHT) live in messages.h.  This file
+// covers the per-widget magic numbers that would otherwise appear as
+// bare integer literals inside paint handlers.
+
+// ── Text rendering ────────────────────────────────────────────────────────
+
+// Standard 1-pixel drop-shadow offset used for all text labels.
+// Shadow is drawn at (x + TEXT_SHADOW_OFFSET, y + TEXT_SHADOW_OFFSET)
+// before the main text pass.
+#define TEXT_SHADOW_OFFSET   1
+
+// ── Buttons ───────────────────────────────────────────────────────────────
+
+// Pixel inset from the button frame to the text/icon content area.
+// Derived from the two-layer bevel drawn by draw_button() (2 px) plus
+// one pixel of inner padding.
+#define BUTTON_TEXT_INSET    3
+
+// ── Checkboxes ────────────────────────────────────────────────────────────
+
+// Width and height of the hit-test box portion of a checkbox control.
+#define CHECKBOX_BOX_SIZE    10
+
+// Pixels by which the focus-ring background extends beyond the box on
+// each side (i.e. focus rect = box expanded by CHECKBOX_FOCUS_PAD).
+#define CHECKBOX_FOCUS_PAD   2
+
+// Horizontal gap between the right edge of the box and the left edge of
+// the label text.
+#define CHECKBOX_GAP         6
+
+// Vertical offset of the label text baseline from the top of the frame.
+#define CHECKBOX_TEXT_Y      2
+
+// ── Labels ────────────────────────────────────────────────────────────────
+
+// Vertical padding applied at the top of a label control before drawing
+// its text (keeps text away from the window border).
+#define LABEL_TEXT_PADDING   3
+
+#endif /* __UI_THEME_H__ */

--- a/user/window.c
+++ b/user/window.c
@@ -136,8 +136,6 @@ static void invalidate_overlaps(window_t *win) {
 
 // Move window to new position
 void move_window(window_t *win, int x, int y) {
-  int dx = x - win->frame.x;
-  int dy = y - win->frame.y;
   post_message(win, kWindowMessageResize, 0, NULL);
   post_message(win, kWindowMessageRefreshStencil, 0, NULL);
 
@@ -146,10 +144,6 @@ void move_window(window_t *win, int x, int y) {
 
   win->frame.x = x;
   win->frame.y = y;
-
-  // Toolbar children carry parent-relative (toolbar-band-relative) frames;
-  // their coordinates are independent of the parent's screen position, so
-  // no explicit shift is needed when the parent window moves.
 
   invalidate_overlaps(win);
 }


### PR DESCRIPTION
Introduce user/rect.h and user/theme.h and update common controls to use them. Replaces many magic-number paint/layout calculations in commctl/button.c, checkbox.c, label.c and list.c with rect_* helpers (inset/offset/center/split_*) and theme constants (TEXT_SHADOW_OFFSET, BUTTON_TEXT_INSET, CHECKBOX_*, LABEL_TEXT_PADDING). Also add rect/theme includes to ui.h and clean up move_window in user/window.c by removing unused shift logic. These changes centralize layout math and visual constants to simplify future UI work and reduce duplicated logic.