### PR TITLE
fix: gitclient declarative form loading — StackView mapping, DiffView plugin, tableview crash

### DIFF
--- a/commctl/tableview.c
+++ b/commctl/tableview.c
@@ -25,8 +25,23 @@
 //                                win_tableview, &params);
 
 #include "../ui.h"
+#include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+
+#ifndef TABLEVIEW_DEBUG
+#define TABLEVIEW_DEBUG 1
+#endif
+
+#if TABLEVIEW_DEBUG
+#define TV_LOG(...) do {                                                      \
+  fprintf(stderr, "[tableview] " __VA_ARGS__);                               \
+  fputc('\n', stderr);                                                        \
+  axLog("[tableview] " __VA_ARGS__);                                         \
+} while (0)
+#else
+#define TV_LOG(...) ((void)0)
+#endif
 
 typedef struct {
   database_t *db;
@@ -120,7 +135,15 @@ static bool tv_get_field_text(tableview_state_t *s, void *record,
 // ══════════════════════════════════════════════════════════════════════════
 
 static void tv_refresh(window_t *win, tableview_state_t *s) {
-  if (!win || !s || !s->db) return;
+  if (!win || !s || !s->db) {
+    TV_LOG("refresh skipped: win=%p state=%p db=%p", (void *)win, (void *)s,
+           s ? (void *)s->db : NULL);
+    return;
+  }
+
+  TV_LOG("refresh begin: id=%u table=%d columns=%d filter=%d:%ld",
+         (unsigned)win->id, s->table_id, s->column_count, s->filter_field,
+         (long)s->filter_value);
   
   // Clear existing items
   send_message(win, RVM_CLEAR, 0, NULL);
@@ -143,7 +166,11 @@ static void tv_refresh(window_t *win, tableview_state_t *s) {
   result_node_t *results = (result_node_t *)send_db_message(s->db, dbFetch,
     MAKEDWORD(s->table_id, s->filter_field), (void *)s->filter_value);
   
-  if (!results) return;
+  if (!results) {
+    TV_LOG("fetch returned no rows: id=%u table=%d", (unsigned)win->id,
+           s->table_id);
+    return;
+  }
   
   // Allocate cell buffers
   char (*cell_buf)[256] = calloc((size_t)s->column_count, sizeof(*cell_buf));
@@ -154,6 +181,7 @@ static void tv_refresh(window_t *win, tableview_state_t *s) {
   
   // Add each record as a row
   int row_idx = 0;
+  int field_failures = 0;
   for (result_node_t *n = results; n; n = (result_node_t *)n->next) {
     void *record = *(void **)n->data;
     if (!record) continue;
@@ -163,6 +191,7 @@ static void tv_refresh(window_t *win, tableview_state_t *s) {
       if (!tv_get_field_text(s, record, s->field_names[col],
                              cell_buf[col], sizeof(cell_buf[col]))) {
         cell_buf[col][0] = '\0';
+        field_failures++;
       }
     }
     
@@ -185,6 +214,8 @@ static void tv_refresh(window_t *win, tableview_state_t *s) {
   
   free(cell_buf);
   free_result_list(results);
+  TV_LOG("refresh complete: id=%u table=%d rows=%d field_failures=%d",
+         (unsigned)win->id, s->table_id, row_idx, field_failures);
 }
 
 // ══════════════════════════════════════════════════════════════════════════
@@ -214,6 +245,8 @@ result_t win_tableview(window_t *win, uint32_t msg, uint32_t wparam, void *lpara
       }
       
       if (!params || !params->field_names) {
+        TV_LOG("create has no table params: id=%u lparam=%p",
+               (unsigned)win->id, lparam);
         // Keep the control alive as a plain reportview to avoid forwarding
         // messages into an uninitialized base state.
         return true;
@@ -230,6 +263,8 @@ result_t win_tableview(window_t *win, uint32_t msg, uint32_t wparam, void *lpara
       s->table_id = params->table_id;
       s->filter_field = params->filter_field;
       s->filter_value = params->filter_value;
+      TV_LOG("create: id=%u table=%d db=%p columns=%d", (unsigned)win->id,
+             s->table_id, (void *)s->db, count_strings(params->field_names));
       
       // Get object proc and field bindings from database (DDX pattern!)
       // Skip if db is NULL (will be set later)
@@ -240,6 +275,9 @@ result_t win_tableview(window_t *win, uint32_t msg, uint32_t wparam, void *lpara
                                                                        (uint32_t)s->table_id, &s->binding_count);
         
         if (!s->obj_proc || !s->bindings) {
+          TV_LOG("create metadata missing: id=%u table=%d object_proc=%p bindings=%p count=%d",
+                 (unsigned)win->id, s->table_id, (void *)s->obj_proc,
+                 (void *)s->bindings, s->binding_count);
           free(s);
           win->userdata = NULL;
           return true;
@@ -305,10 +343,19 @@ result_t win_tableview(window_t *win, uint32_t msg, uint32_t wparam, void *lpara
                                                          (uint32_t)s->table_id, NULL);
         s->bindings = (const db_field_msg_binding_t *)send_db_message(s->db, dbGetFieldBindings,
                                                                        (uint32_t)s->table_id, &s->binding_count);
+        TV_LOG("database attached: id=%u table=%d db=%p object_proc=%p bindings=%p count=%d",
+               (unsigned)win->id, s->table_id, (void *)s->db,
+               (void *)s->obj_proc, (void *)s->bindings, s->binding_count);
         // Refresh from database
         if (s->obj_proc && s->bindings) {
           tv_refresh(win, s);
+        } else {
+          TV_LOG("database API incomplete: id=%u table=%d", (unsigned)win->id,
+                 s->table_id);
         }
+      } else {
+        TV_LOG("database attach skipped: id=%u state=%p db=%p",
+               (unsigned)win->id, (void *)s, lparam);
       }
       return true;
     

--- a/components/gitclient/diff_view.c
+++ b/components/gitclient/diff_view.c
@@ -1,0 +1,164 @@
+#include "diff_view.h"
+#include "../../user/vga_font.h"
+#include "../../user/ansi.h"
+#include "../../kernel/renderer.h"
+
+#define CLR_ADD_BG   0xFF1A3A1A
+#define CLR_ADD_FG   0xFF66FF66
+#define CLR_DEL_BG   0xFF3A1A1A
+#define CLR_DEL_FG   0xFFFF6666
+#define CLR_HUNK_BG  0xFF1A1A3A
+#define CLR_HUNK_FG   0xFF66CCFF
+#define CLR_CTX_BG   0xFF1E1E1E
+#define CLR_CTX_FG   0xFFCCCCCC
+#define CLR_LNUM_BG  0xFF2A2A2A
+#define CLR_LNUM_FG  0xFF888888
+#define CLR_HEADER_BG 0xFF2E2E2E
+#define CLR_HEADER_FG 0xFFAAAAAA
+
+#define LINE_NUM_W    (5 * VGA_CHAR_W)
+
+#define GC_DIFF_USE_PREFIX_COLORS 0
+
+static int visible_lines(window_t *win) {
+  return MAX(1, win->frame.h / VGA_CHAR_H);
+}
+
+static int max_scroll_start(window_t *win, const gc_diff_state_t *st) {
+  if (!win || !st) return 0;
+  return MAX(0, st->line_count - visible_lines(win));
+}
+
+result_t gc_diff_proc(window_t *win, uint32_t msg,
+                      uint32_t wparam, void *lparam) {
+  switch (msg) {
+    case evCreate: {
+      gc_diff_state_t *st = (gc_diff_state_t *)calloc(1, sizeof(gc_diff_state_t));
+      win->userdata = st;
+      return true;
+    }
+
+    case evDestroy: {
+      gc_diff_state_t *st = (gc_diff_state_t *)win->userdata;
+      if (st) {
+        free(st->lines);
+        vga_text_free_grid(&st->grid);
+        free(st);
+        win->userdata = NULL;
+      }
+      return false;
+    }
+
+    case evResize: {
+      gc_diff_state_t *st = (gc_diff_state_t *)win->userdata;
+      if (!st) return false;
+      st->scroll_y = CLAMP(st->scroll_y, 0, max_scroll_start(win, st));
+      scroll_info_t si = {
+        .fMask = SIF_PAGE | SIF_POS,
+        .nPage = (uint32_t)visible_lines(win),
+        .nPos = st->scroll_y,
+      };
+      set_scroll_info(win, SB_VERT, &si, true);
+      invalidate_window(win);
+      return false;
+    }
+
+    case evVScroll: {
+      gc_diff_state_t *st = (gc_diff_state_t *)win->userdata;
+      if (!st) return false;
+      st->scroll_y = CLAMP((int)wparam, 0, max_scroll_start(win, st));
+      scroll_info_t si = { .fMask = SIF_POS, .nPos = st->scroll_y };
+      set_scroll_info(win, SB_VERT, &si, false);
+      invalidate_window(win);
+      return true;
+    }
+
+    case evWheel: {
+      gc_diff_state_t *st = (gc_diff_state_t *)win->userdata;
+      if (!st || !st->line_count) return false;
+      int delta = (int16_t)HIWORD((uintptr_t)lparam);
+      if (delta == 0) return false;
+      int lines = delta < 0 ? 3 : -3;
+      int max_start = max_scroll_start(win, st);
+      int new_pos = CLAMP(st->scroll_y + lines, 0, max_start);
+      if (new_pos != st->scroll_y) {
+        st->scroll_y = new_pos;
+        scroll_info_t si = { .fMask = SIF_POS, .nPos = st->scroll_y };
+        set_scroll_info(win, SB_VERT, &si, false);
+        invalidate_window(win);
+      }
+      return true;
+    }
+
+    case evPaint: {
+      gc_diff_state_t *st = (gc_diff_state_t *)win->userdata;
+      irect16_t cr = get_client_rect(win);
+
+      fill_rect(CLR_CTX_BG, cr);
+
+      if (!st || !st->lines || !st->line_count) {
+        draw_text_small("No diff content.", cr.x + 4, cr.y + 4,
+                        get_sys_color(brTextDisabled));
+        return true;
+      }
+
+      int vis   = visible_lines(win);
+      int start = CLAMP(st->scroll_y, 0, max_scroll_start(win, st));
+      int end   = MIN(start + vis, st->line_count);
+
+      int text_w = cr.w - LINE_NUM_W;
+      if (text_w < 8) text_w = 8;
+
+      int max_cols = text_w / VGA_CHAR_W;
+      int gutter_cols = LINE_NUM_W / VGA_CHAR_W;
+      int total_cols = gutter_cols + max_cols;
+
+      if (total_cols <= 0 || vis <= 0) return true;
+
+      if (!vga_text_ensure_grid(&st->grid, total_cols, vis)) return true;
+
+      int def_fg_idx = nearest_ansi_index(CLR_CTX_FG);
+      int def_bg_idx = nearest_ansi_index(CLR_CTX_BG);
+      vga_text_clear_grid(&st->grid, def_fg_idx, def_bg_idx);
+
+      int lnum_fg_idx = nearest_ansi_index(CLR_LNUM_FG);
+      int lnum_bg_idx = nearest_ansi_index(CLR_LNUM_BG);
+
+      for (int li = start; li < end; li++) {
+        const char *line = st->lines[li];
+        int row = li - start;
+
+        uint32_t fg = CLR_CTX_FG;
+        uint32_t bg = CLR_CTX_BG;
+
+        char lnum[16];
+        snprintf(lnum, sizeof(lnum), "%4d ", li + 1);
+        for (int c = 0; c < gutter_cols; c++) {
+          unsigned char ch = (unsigned char)(lnum[c] ? lnum[c] : ' ');
+          vga_text_set_cell(&st->grid, c, row, ch, lnum_fg_idx, lnum_bg_idx);
+        }
+
+        vga_text_write_ansi_line(line, &st->grid, row, gutter_cols, max_cols, fg, bg);
+      }
+
+      if (R_UpdateTextureRG8(st->grid.cells_tex, 0, 0, st->grid.cells_w, st->grid.cells_h, st->grid.cells)) {
+        R_VgaBuffer buf = {
+          .vga_buffer = st->grid.cells_tex,
+          .width = st->grid.cells_w,
+          .height = st->grid.cells_h,
+        };
+        R_DrawVGABuffer(&buf,
+                        cr.x, cr.y,
+                        st->grid.cells_w * VGA_CHAR_W,
+                        st->grid.cells_h * VGA_CHAR_H,
+                        vga_font_texture_id(),
+                        kAnsi16);
+      }
+
+      return true;
+    }
+
+    default:
+      return false;
+  }
+}

--- a/components/gitclient/diff_view.h
+++ b/components/gitclient/diff_view.h
@@ -1,0 +1,21 @@
+#ifndef GC_DIFF_VIEW_H
+#define GC_DIFF_VIEW_H
+
+#include "../../user/vga_text.h"
+#include "../../ui.h"
+
+#define GC_DIFF_VIEW_CLASS_NAME "DiffView"
+
+#define GC_DIFF_BUF_SIZE (256 * 1024)
+
+typedef struct {
+  char  **lines;
+  int     line_count;
+  int     scroll_y;
+  vga_text_grid_t grid;
+  char    diff_buf[GC_DIFF_BUF_SIZE];
+} gc_diff_state_t;
+
+result_t gc_diff_proc(window_t *win, uint32_t msg, uint32_t wparam, void *lparam);
+
+#endif

--- a/components/gitclient/plug.c
+++ b/components/gitclient/plug.c
@@ -1,0 +1,17 @@
+#include "../../ui.h"
+#include "../../user/icons.h"
+#include "diff_view.h"
+
+static const fe_component_desc_t k_gitclient_components[] = {
+  {
+    .class_name   = GC_DIFF_VIEW_CLASS_NAME,
+    .name_prefix  = "GC_DIFF",
+    .toolbox_icon = sysicon_page_data,
+    .default_size = {260, 480},
+    .default_layout_size = {0, 480},
+    .capabilities = 0,
+    .proc         = gc_diff_proc,
+  },
+};
+
+GEM_CLASSES(k_gitclient_components, "GitClient components", FE_PLUGIN_VERSION)

--- a/examples/formeditor/fe_project_io.c
+++ b/examples/formeditor/fe_project_io.c
@@ -310,7 +310,6 @@ static uint32_t flag_value(const char *tok) {
   if (strcmp(tok, "WINDOW_FLEXSPACE") == 0) return WINDOW_FLEXSPACE;
   if (strcmp(tok, "WINDOW_AUTO_LAYOUT") == 0) return WINDOW_AUTO_LAYOUT;
   if (strcmp(tok, "WINDOW_LAYOUT_CONTAINER") == 0) return WINDOW_LAYOUT_CONTAINER;
-  if (strcmp(tok, "WINDOW_SIDEBAR") == 0) return WINDOW_SIDEBAR;
   if (strcmp(tok, "BUTTON_PUSHLIKE") == 0) return BUTTON_PUSHLIKE;
   if (strcmp(tok, "BUTTON_AUTORADIO") == 0) return BUTTON_AUTORADIO;
   char *end = NULL;

--- a/examples/gitclient/controller.c
+++ b/examples/gitclient/controller.c
@@ -10,6 +10,10 @@ void gc_load_from_git(void) {
   gc_state_t *gc = g_gc;
   if (!gc || !gc->repo || !gc->db) return;
 
+  int branch_count = 0;
+  int commit_count = 0;
+  int file_count = 0;
+
   send_db_message(gc->db, dbDelete, ID_DB_BRANCHES, (void *)(intptr_t)0);
   send_db_message(gc->db, dbDelete, ID_DB_COMMITS,  (void *)(intptr_t)0);
   send_db_message(gc->db, dbDelete, ID_DB_FILES,    (void *)(intptr_t)0);
@@ -18,6 +22,7 @@ void gc_load_from_git(void) {
   {
     git_branch_t raw[128];
     int count = git_get_branches(gc->repo, raw, 128);
+    branch_count = count;
     for (int i = 0; i < count; i++) {
       db_branche_t rec = {0};
       strncpy(rec.name, raw[i].name, sizeof(rec.name) - 1);
@@ -30,6 +35,7 @@ void gc_load_from_git(void) {
   {
     git_commit_t raw[500];
     int count = git_get_log(gc->repo, raw, 500);
+    commit_count = count;
     for (int i = 0; i < count; i++) {
       db_commit_t rec = {0};
       strncpy(rec.hash,    raw[i].hash,    sizeof(rec.hash) - 1);
@@ -43,6 +49,7 @@ void gc_load_from_git(void) {
   {
     git_file_status_t raw[256];
     int count = git_get_status(gc->repo, raw, 256);
+    file_count = count;
     for (int i = 0; i < count; i++) {
       db_file_t rec = {0};
       strncpy(rec.path, raw[i].path, sizeof(rec.path) - 1);
@@ -53,7 +60,8 @@ void gc_load_from_git(void) {
     }
   }
 
-  GC_LOG("gc_load_from_git: loaded branches, commits, files");
+  GC_LOG("database populated: branches=%d commits=%d files=%d",
+         branch_count, commit_count, file_count);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/examples/gitclient/gitclient.h
+++ b/examples/gitclient/gitclient.h
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 
 #include "../../ui.h"
+#include "../../components/gitclient/diff_view.h"
 #include "../../commctl/columnview.h"
 #include "../../commctl/menubar.h"
 #include "../../user/accel.h"
@@ -25,7 +26,11 @@
 #endif
 
 #if GITCLIENT_DEBUG
-#define GC_LOG(...) do { axLog("[gitclient] " __VA_ARGS__); } while (0)
+#define GC_LOG(...) do {                                                      \
+  fprintf(stderr, "[gitclient] " __VA_ARGS__);                               \
+  fputc('\n', stderr);                                                        \
+  axLog("[gitclient] " __VA_ARGS__);                                         \
+} while (0)
 #else
 #define GC_LOG(...) ((void)0)
 #endif
@@ -36,11 +41,6 @@
 
 #define SCREEN_W         800
 #define SCREEN_H         480
-
-#define PANEL_SPLITTER   4
-#define PANEL_LEFT_W_DEFAULT   180
-#define PANEL_RIGHT_W_DEFAULT  260
-#define PANEL_VSPLIT_FRAC      60
 
 // ============================================================
 // Custom event messages
@@ -158,15 +158,6 @@ typedef struct {
   window_t    *files_win;
   window_t    *diff_win;
 
-  // Splitter state
-  int          right_w;
-  int          vsplit_y;
-  window_t    *vsplitter_win;
-  window_t    *hsplitter_win;
-  window_t    *dragging_splitter;
-  int          drag_start_mouse;
-  int          drag_start_val;
-
   accel_table_t *accel;
   hinstance_t    hinstance;
 } gc_state_t;
@@ -235,14 +226,11 @@ result_t gc_main_proc(window_t *win, uint32_t msg,
 void gc_open_repo(const char *path);
 void gc_refresh_all(void);
 void gc_update_status(void);
-void gc_layout_panels(window_t *win);
 
 // ============================================================
 // View — diff viewer (view_diff.c)
 // ============================================================
 
-result_t gc_diff_proc(window_t *win, uint32_t msg,
-                      uint32_t wparam, void *lparam);
 void gc_diff_refresh(void);
 
 // ============================================================

--- a/examples/gitclient/gitclient.orion
+++ b/examples/gitclient/gitclient.orion
@@ -95,16 +95,21 @@
         </database>
     </databases>
 
+    <plugins>
+        <plugin name="gitclient_components" />
+    </plugins>
+
     <forms>
         <form name="main_window"
               title="Git Client"
               width="800" height="480"
               flags="toolbar,statusbar"
               toolbar="main">
+            <requires library="gitclient_components" />
             <stack orientation="horizontal" spacing="0" flags="flexspace">
                 <TableView name="branches"
                            source="db.branches"
-                           flags="notitle,nofill,vscroll,flexspace"
+                           flags="notitle,nofill,vscroll"
                            width="180">
                     <Column field="name" title="" width="0" />
                 </TableView>
@@ -127,9 +132,9 @@
                     </TableView>
                 </stack>
 
-                <Window name="diff"
-                        flags="notitle,nofill,vscroll,flexspace"
-                        width="260" />
+                <DiffView name="diff"
+                          flags="notitle,nofill,vscroll"
+                          width="260" />
             </stack>
         </form>
 

--- a/examples/gitclient/gitclient_db.c
+++ b/examples/gitclient/gitclient_db.c
@@ -59,6 +59,92 @@ static db_schema_def_t gitclient_database_schema = {
   .table_count = TABLE_COUNT,
 };
 
+enum {
+  GC_COL_BRANCH_ID,
+  GC_COL_BRANCH_NAME,
+  GC_COL_BRANCH_HASH,
+  GC_COL_BRANCH_IS_CURRENT,
+  GC_COL_BRANCH_IS_REMOTE,
+  GC_COL_COMMIT_ID,
+  GC_COL_COMMIT_HASH,
+  GC_COL_COMMIT_AUTHOR,
+  GC_COL_COMMIT_DATE,
+  GC_COL_COMMIT_SUBJECT,
+  GC_COL_FILE_ID,
+  GC_COL_FILE_PATH,
+  GC_COL_FILE_STATUS,
+  GC_COL_FILE_STAGED,
+  GC_COL_DIFF_ID,
+  GC_COL_DIFF_CONTENT,
+};
+
+static result_t field_text_from_meta(const void *object,
+                                     const db_field_meta_t *fields,
+                                     int field_count, int first_column,
+                                     uint32_t msg, uint32_t wparam,
+                                     void *lparam) {
+  if (msg != dbObjGetFieldText || !object || !fields || !lparam)
+    return false;
+
+  int field_index = (int)LOWORD(wparam) - first_column;
+  size_t buf_sz = (size_t)HIWORD(wparam);
+  if (field_index < 0 || field_index >= field_count || buf_sz == 0)
+    return false;
+
+  const db_field_meta_t *field = &fields[field_index];
+  const void *value = (const char *)object + field->offset;
+  char *buf = (char *)lparam;
+  switch (field->type) {
+    case DB_TYPE_INT:
+      snprintf(buf, buf_sz, "%d", *(const int *)value);
+      return true;
+    case DB_TYPE_STRING:
+      snprintf(buf, buf_sz, "%s", (const char *)value);
+      return true;
+    case DB_TYPE_BOOL:
+      snprintf(buf, buf_sz, "%d", *(const bool *)value ? 1 : 0);
+      return true;
+    case DB_TYPE_FLOAT:
+      snprintf(buf, buf_sz, "%g", *(const float *)value);
+      return true;
+    case DB_TYPE_DOUBLE:
+      snprintf(buf, buf_sz, "%g", *(const double *)value);
+      return true;
+  }
+  return false;
+}
+
+#define GC_OBJECT_PROC(name, fields, first_column)                              \
+  static result_t name(const void *object, uint32_t msg, uint32_t wparam,       \
+                       void *lparam) {                                           \
+    return field_text_from_meta(object, fields, ARRAY_LEN(fields), first_column,\
+                                msg, wparam, lparam);                            \
+  }
+
+GC_OBJECT_PROC(branch_object_proc, branches_fields, GC_COL_BRANCH_ID)
+GC_OBJECT_PROC(commit_object_proc, commits_fields, GC_COL_COMMIT_ID)
+GC_OBJECT_PROC(file_object_proc, files_fields, GC_COL_FILE_ID)
+GC_OBJECT_PROC(diff_object_proc, diff_fields, GC_COL_DIFF_ID)
+
+static const db_field_msg_binding_t branch_field_bindings[] = {
+  { "id", GC_COL_BRANCH_ID }, { "name", GC_COL_BRANCH_NAME },
+  { "hash", GC_COL_BRANCH_HASH },
+  { "is_current", GC_COL_BRANCH_IS_CURRENT },
+  { "is_remote", GC_COL_BRANCH_IS_REMOTE },
+};
+static const db_field_msg_binding_t commit_field_bindings[] = {
+  { "id", GC_COL_COMMIT_ID }, { "hash", GC_COL_COMMIT_HASH },
+  { "author", GC_COL_COMMIT_AUTHOR }, { "date", GC_COL_COMMIT_DATE },
+  { "subject", GC_COL_COMMIT_SUBJECT },
+};
+static const db_field_msg_binding_t file_field_bindings[] = {
+  { "id", GC_COL_FILE_ID }, { "path", GC_COL_FILE_PATH },
+  { "status", GC_COL_FILE_STATUS }, { "staged", GC_COL_FILE_STAGED },
+};
+static const db_field_msg_binding_t diff_field_bindings[] = {
+  { "id", GC_COL_DIFF_ID }, { "content", GC_COL_DIFF_CONTENT },
+};
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Internal context
 // ═══════════════════════════════════════════════════════════════════════════
@@ -279,6 +365,10 @@ lresult_t gitclient_db(database_t *db, uint32_t msg, uint32_t wparam, void *lpar
       int filter_field = HIWORD(wparam);
       int filter_value = (int)(intptr_t)lparam;
 
+      GC_LOG("dbFetch: table=%d filter_field=%d filter_value=%d counts=[%d,%d,%d,%d]",
+             table_id, filter_field, filter_value, ctx->branch_count,
+             ctx->commit_count, ctx->file_count, ctx->diff_count);
+
       if (table_id == ID_DB_BRANCHES) {
         if (filter_field == ID_DB_BRANCHES_IS_REMOTE)
           return fetch_filtered_bool(ctx->branches, ctx->branch_count,
@@ -331,6 +421,36 @@ lresult_t gitclient_db(database_t *db, uint32_t msg, uint32_t wparam, void *lpar
 
     case dbGetDirty:
       return 0;
+
+    case dbGetObjectProc:
+      switch ((int)wparam) {
+        case ID_DB_BRANCHES: return (lresult_t)branch_object_proc;
+        case ID_DB_COMMITS:  return (lresult_t)commit_object_proc;
+        case ID_DB_FILES:    return (lresult_t)file_object_proc;
+        case ID_DB_DIFF:     return (lresult_t)diff_object_proc;
+        default:             return (lresult_t)NULL;
+      }
+
+    case dbGetFieldBindings: {
+      int *count_out = (int *)lparam;
+      switch ((int)wparam) {
+        case ID_DB_BRANCHES:
+          if (count_out) *count_out = ARRAY_LEN(branch_field_bindings);
+          return (lresult_t)branch_field_bindings;
+        case ID_DB_COMMITS:
+          if (count_out) *count_out = ARRAY_LEN(commit_field_bindings);
+          return (lresult_t)commit_field_bindings;
+        case ID_DB_FILES:
+          if (count_out) *count_out = ARRAY_LEN(file_field_bindings);
+          return (lresult_t)file_field_bindings;
+        case ID_DB_DIFF:
+          if (count_out) *count_out = ARRAY_LEN(diff_field_bindings);
+          return (lresult_t)diff_field_bindings;
+        default:
+          if (count_out) *count_out = 0;
+          return (lresult_t)NULL;
+      }
+    }
 
     case dbGetSchema:
       gc_database_schema.name = db->name;

--- a/examples/gitclient/main.c
+++ b/examples/gitclient/main.c
@@ -16,31 +16,46 @@ gc_state_t *g_gc = NULL;
 // ============================================================
 
 bool gem_init(int argc, char *argv[], hinstance_t hinstance) {
+#if GITCLIENT_DEBUG
+  {
+    char log_path[1024];
+    int n = snprintf(log_path, sizeof(log_path), "%s/gitclient.log",
+                     axSettingsDirectory());
+    if (n > 0 && (size_t)n < sizeof(log_path) && axSetLogFile(log_path))
+      GC_LOG("logging initialized: %s", axGetLogFile());
+  }
+#endif
+
   memset(&g_gc_state, 0, sizeof(g_gc_state));
   g_gc = &g_gc_state;
 
   g_gc->hinstance       = hinstance;
   g_gc->selected_commit = -1;
   g_gc->selected_file   = -1;
-  g_gc->right_w         = PANEL_RIGHT_W_DEFAULT;
 
   // Register database class and create database.
   DB_CLASS(gitclient_db);
   g_gc->db = create_database("gitclient", "gitclient_db", NULL);
   if (!g_gc->db) return false;
-  register_database("db", g_gc->db);
+  bool db_registered = register_database("db", g_gc->db);
+  ui_set_database(g_gc->db);
+  GC_LOG("database ready: db=%p registered=%d global=%p",
+         (void *)g_gc->db, db_registered, (void *)ui_get_database());
 
   // Register commctl classes (tableview, stack, grid, etc.).
   register_commctl_classes();
 
+  // Load gitclient component plugin (DiffView, etc.).
+  {
+    char path[4096];
+    int n = snprintf(path, sizeof(path), "%s/../lib/gitclient_components%s",
+                     ui_get_exe_dir(), AX_DYNLIB_EXT);
+    if (n > 0 && (size_t)n < sizeof(path))
+      fe_load_component_plugin(path);
+  }
+
   // Menubar + accelerators.
   gc_create_menubar();
-
-  // Calculate initial vsplit_y.
-  int sh = ui_get_system_metrics(kSystemMetricScreenHeight);
-  int mh = sh - MENUBAR_HEIGHT;
-  g_gc->vsplit_y = (int)(mh * PANEL_VSPLIT_FRAC / 100);
-  if (g_gc->vsplit_y < 60) g_gc->vsplit_y = 60;
 
   // Create main window from form definition.
   g_gc->main_win = create_window_from_form(&gc_main_window_form, 0, 0,
@@ -49,16 +64,28 @@ bool gem_init(int argc, char *argv[], hinstance_t hinstance) {
   if (!g_gc->main_win) return false;
   show_window(g_gc->main_win, true);
 
-  // If a path was passed on the command line, open it immediately.
-  if (argc > 1 && argv[1] && argv[1][0])
+  // Open an explicit repository, or use the launch directory when it is one.
+  if (argc > 1 && argv[1] && argv[1][0]) {
     gc_open_repo(argv[1]);
+  } else {
+    git_repo_t *cwd_repo = git_repo_open(".");
+    if (cwd_repo) {
+      git_repo_close(cwd_repo);
+      gc_open_repo(".");
+    } else {
+      GC_LOG("startup directory is not a repository; waiting for Open Repository");
+    }
+  }
 
   return true;
 }
 
 void gem_shutdown(void) {
+  fe_unload_component_plugins();
   if (g_gc) {
     if (g_gc->db) {
+      if (ui_get_database() == g_gc->db)
+        ui_set_database(NULL);
       destroy_database(g_gc->db);
       g_gc->db = NULL;
     }
@@ -66,6 +93,10 @@ void gem_shutdown(void) {
       free_accelerators(g_gc->accel);
     g_gc = NULL;
   }
+#if GITCLIENT_DEBUG
+  GC_LOG("logging shutdown");
+  axSetLogFile(NULL);
+#endif
 }
 
 GEM_DEFINE("Git Client", "1.0", gem_init, gem_shutdown, NULL)

--- a/examples/gitclient/view_diff.c
+++ b/examples/gitclient/view_diff.c
@@ -1,66 +1,18 @@
-// Unified diff viewer — custom window proc using VGA monospace font.
+// Unified diff viewer — fill content into gc_diff_state_t
 //
 // Reads selected file/commit from DB to determine what diff to show.
+// The window proc lives in the gitclient_components plugin (diff_view.c).
 
 #include "gitclient.h"
+#include "../../components/gitclient/diff_view.h"
 #include "../../user/vga_font.h"
-#include "../../user/ansi.h"
-#include "../../user/vga_text.h"
-
-// ============================================================
-// Colours (0xAARRGGBB)
-// ============================================================
-
-#define CLR_ADD_BG   0xFF1A3A1A
-#define CLR_ADD_FG   0xFF66FF66
-#define CLR_DEL_BG   0xFF3A1A1A
-#define CLR_DEL_FG   0xFFFF6666
-#define CLR_HUNK_BG  0xFF1A1A3A
-#define CLR_HUNK_FG   0xFF66CCFF
-#define CLR_CTX_BG   0xFF1E1E1E
-#define CLR_CTX_FG   0xFFCCCCCC
-#define CLR_LNUM_BG  0xFF2A2A2A
-#define CLR_LNUM_FG  0xFF888888
-#define CLR_HEADER_BG 0xFF2E2E2E
-#define CLR_HEADER_FG 0xFFAAAAAA
-
-#define LINE_NUM_W    (5 * VGA_CHAR_W)
-
-#ifndef GC_DIFF_USE_PREFIX_COLORS
-#define GC_DIFF_USE_PREFIX_COLORS 0
-#endif
-
-// ============================================================
-// Per-window state
-// ============================================================
-
-typedef struct {
-  char  **lines;
-  int     line_count;
-  int     scroll_y;
-  vga_text_grid_t grid;
-  char    diff_buf[256 * 1024];
-} diff_state_t;
-
-static int visible_lines(window_t *win) {
-  return MAX(1, win->frame.h / VGA_CHAR_H);
-}
-
-static int max_scroll_start(window_t *win, const diff_state_t *st) {
-  if (!win || !st) return 0;
-  return MAX(0, st->line_count - visible_lines(win));
-}
-
-// ============================================================
-// Refresh: get diff from git based on DB selection
-// ============================================================
 
 void gc_diff_refresh(void) {
   gc_state_t *gc = g_gc;
   if (!gc || !gc->diff_win) return;
 
   window_t *win = gc->diff_win;
-  diff_state_t *st = (diff_state_t *)win->userdata;
+  gc_diff_state_t *st = (gc_diff_state_t *)win->userdata;
   if (!st) return;
 
   free(st->lines);
@@ -73,12 +25,10 @@ void gc_diff_refresh(void) {
     return;
   }
 
-  // Determine what diff to show from DB state.
   const char *path = NULL;
   bool staged = false;
 
   if (gc->selected_file >= 0) {
-    // Fetch the selected file from DB.
     result_node_t *files = (result_node_t *)send_db_message(
       gc->db, dbFetch, MAKEDWORD(ID_DB_FILES, 0), (void *)(intptr_t)0);
     result_node_t *node = files;
@@ -92,7 +42,6 @@ void gc_diff_refresh(void) {
   }
 
   if (gc->selected_commit >= 0) {
-    // Fetch the selected commit from DB.
     result_node_t *commits = (result_node_t *)send_db_message(
       gc->db, dbFetch, MAKEDWORD(ID_DB_COMMITS, 0), (void *)(intptr_t)0);
     result_node_t *node = commits;
@@ -122,7 +71,6 @@ void gc_diff_refresh(void) {
     return;
   }
 
-  // Count lines.
   int count = 0;
   for (char *p = st->diff_buf; *p; p++)
     if (*p == '\n') count++;
@@ -144,161 +92,9 @@ void gc_diff_refresh(void) {
     .fMask = SIF_RANGE | SIF_PAGE | SIF_POS,
     .nMin  = 0,
     .nMax  = st->line_count,
-    .nPage = (uint32_t)visible_lines(win),
+    .nPage = (uint32_t)MAX(1, win->frame.h / VGA_CHAR_H),
     .nPos  = 0,
   };
   set_scroll_info(win, SB_VERT, &si, false);
   invalidate_window(win);
-}
-
-// ============================================================
-// Window procedure
-// ============================================================
-
-result_t gc_diff_proc(window_t *win, uint32_t msg,
-                      uint32_t wparam, void *lparam) {
-  switch (msg) {
-    case evCreate: {
-      diff_state_t *st = (diff_state_t *)calloc(1, sizeof(diff_state_t));
-      win->userdata = st;
-      return true;
-    }
-
-    case evDestroy: {
-      diff_state_t *st = (diff_state_t *)win->userdata;
-      if (st) {
-        free(st->lines);
-        vga_text_free_grid(&st->grid);
-        free(st);
-        win->userdata = NULL;
-      }
-      return false;
-    }
-
-    case evResize: {
-      diff_state_t *st = (diff_state_t *)win->userdata;
-      if (!st) return false;
-      st->scroll_y = CLAMP(st->scroll_y, 0, max_scroll_start(win, st));
-      scroll_info_t si = {
-        .fMask = SIF_PAGE | SIF_POS,
-        .nPage = (uint32_t)visible_lines(win),
-        .nPos = st->scroll_y,
-      };
-      set_scroll_info(win, SB_VERT, &si, true);
-      invalidate_window(win);
-      return false;
-    }
-
-    case evVScroll: {
-      diff_state_t *st = (diff_state_t *)win->userdata;
-      if (!st) return false;
-      st->scroll_y = CLAMP((int)wparam, 0, max_scroll_start(win, st));
-      scroll_info_t si = { .fMask = SIF_POS, .nPos = st->scroll_y };
-      set_scroll_info(win, SB_VERT, &si, false);
-      invalidate_window(win);
-      return true;
-    }
-
-    case evWheel: {
-      diff_state_t *st = (diff_state_t *)win->userdata;
-      if (!st || !st->line_count) return false;
-      int delta = (int16_t)HIWORD((uintptr_t)lparam);
-      if (delta == 0) return false;
-      int lines = delta < 0 ? 3 : -3;
-      int max_start = max_scroll_start(win, st);
-      int new_pos = CLAMP(st->scroll_y + lines, 0, max_start);
-      if (new_pos != st->scroll_y) {
-        st->scroll_y = new_pos;
-        scroll_info_t si = { .fMask = SIF_POS, .nPos = st->scroll_y };
-        set_scroll_info(win, SB_VERT, &si, false);
-        invalidate_window(win);
-      }
-      return true;
-    }
-
-    case evPaint: {
-      diff_state_t *st = (diff_state_t *)win->userdata;
-      irect16_t cr = get_client_rect(win);
-
-      fill_rect(CLR_CTX_BG, cr);
-
-      if (!st || !st->lines) {
-        if (!g_gc || !g_gc->repo) {
-          draw_text_small("No repository open.", cr.x + 4, cr.y + 4,
-                          get_sys_color(brTextDisabled));
-        } else {
-          draw_text_small("Select a file to view its diff.",
-                          cr.x + 4, cr.y + 4,
-                          get_sys_color(brTextDisabled));
-        }
-        return true;
-      }
-
-      int vis   = visible_lines(win);
-      int start = CLAMP(st->scroll_y, 0, max_scroll_start(win, st));
-      int end   = MIN(start + vis, st->line_count);
-
-      int text_w = cr.w - LINE_NUM_W;
-      if (text_w < 8) text_w = 8;
-
-      int max_cols = text_w / VGA_CHAR_W;
-      int gutter_cols = LINE_NUM_W / VGA_CHAR_W;
-      int total_cols = gutter_cols + max_cols;
-
-      if (total_cols <= 0 || vis <= 0) return true;
-
-      if (!vga_text_ensure_grid(&st->grid, total_cols, vis)) return true;
-
-      int def_fg_idx = nearest_ansi_index(CLR_CTX_FG);
-      int def_bg_idx = nearest_ansi_index(CLR_CTX_BG);
-      vga_text_clear_grid(&st->grid, def_fg_idx, def_bg_idx);
-
-      int lnum_fg_idx = nearest_ansi_index(CLR_LNUM_FG);
-      int lnum_bg_idx = nearest_ansi_index(CLR_LNUM_BG);
-
-      for (int li = start; li < end; li++) {
-        const char *line = st->lines[li];
-        int row = li - start;
-
-        uint32_t fg = CLR_CTX_FG;
-        uint32_t bg = CLR_CTX_BG;
-#if GC_DIFF_USE_PREFIX_COLORS
-        char first = line[0];
-        if (first == '+') { fg = CLR_ADD_FG; bg = CLR_ADD_BG; }
-        else if (first == '-') { fg = CLR_DEL_FG; bg = CLR_DEL_BG; }
-        else if (first == '@') { fg = CLR_HUNK_FG; bg = CLR_HUNK_BG; }
-        else if (first == 'd' || first == 'i' || first == 'n' || first == 'B')
-          { fg = CLR_HEADER_FG; bg = CLR_HEADER_BG; }
-#endif
-
-        char lnum[16];
-        snprintf(lnum, sizeof(lnum), "%4d ", li + 1);
-        for (int c = 0; c < gutter_cols; c++) {
-          unsigned char ch = (unsigned char)(lnum[c] ? lnum[c] : ' ');
-          vga_text_set_cell(&st->grid, c, row, ch, lnum_fg_idx, lnum_bg_idx);
-        }
-
-        vga_text_write_ansi_line(line, &st->grid, row, gutter_cols, max_cols, fg, bg);
-      }
-
-      if (R_UpdateTextureRG8(st->grid.cells_tex, 0, 0, st->grid.cells_w, st->grid.cells_h, st->grid.cells)) {
-        R_VgaBuffer buf = {
-          .vga_buffer = st->grid.cells_tex,
-          .width = st->grid.cells_w,
-          .height = st->grid.cells_h,
-        };
-        R_DrawVGABuffer(&buf,
-                        cr.x, cr.y,
-                        st->grid.cells_w * VGA_CHAR_W,
-                        st->grid.cells_h * VGA_CHAR_H,
-                        vga_font_texture_id(),
-                        kAnsi16);
-      }
-
-      return true;
-    }
-
-    default:
-      return false;
-  }
 }

--- a/examples/gitclient/view_main.c
+++ b/examples/gitclient/view_main.c
@@ -4,79 +4,6 @@
 #include "../../user/vga_font.h"
 
 // ============================================================
-// Layout helpers
-// ============================================================
-
-static void compute_layout(gc_state_t *gc, irect16_t *cr,
-                            irect16_t *r_log,
-                            irect16_t *r_files,
-                            irect16_t *r_diff) {
-  int lw = PANEL_LEFT_W_DEFAULT + PANEL_SPLITTER;
-  int rw = gc->right_w;
-  int total_w = cr->w;
-  int total_h = cr->h;
-
-  rw = CLAMP(rw, 80, total_w - lw - 80);
-  gc->right_w = rw;
-
-  int center_x = cr->x + lw;
-  int center_w = total_w - lw - rw - PANEL_SPLITTER;
-  if (center_w < 20) center_w = 20;
-
-  int vs = CLAMP(gc->vsplit_y, 40, total_h - 40);
-  gc->vsplit_y = vs;
-
-  *r_diff  = (irect16_t){ cr->x + total_w - rw, cr->y, rw, total_h };
-  *r_log   = (irect16_t){ center_x, cr->y, center_w, vs };
-  *r_files = (irect16_t){ center_x, cr->y + vs + PANEL_SPLITTER,
-                        center_w, total_h - vs - PANEL_SPLITTER };
-}
-
-void gc_layout_panels(window_t *win) {
-  gc_state_t *gc = (gc_state_t *)win->userdata;
-  if (!gc) return;
-
-  irect16_t cr = get_client_rect(win);
-  irect16_t rl, rf, rd;
-  compute_layout(gc, &cr, &rl, &rf, &rd);
-
-  if (win->sidebar) {
-    int sb_w = win->sidebar->layout.layout_fixed_w;
-    if (sb_w <= 0) sb_w = win->sidebar->frame.w;
-    if (sb_w <= 0) sb_w = SIDEBAR_DEFAULT_WIDTH;
-    move_window(win->sidebar, 0, 0);
-    resize_window(win->sidebar, sb_w, cr.h);
-  }
-  if (gc->log_win) {
-    move_window(gc->log_win, rl.x, rl.y);
-    resize_window(gc->log_win, rl.w, rl.h);
-  }
-  if (gc->files_win) {
-    move_window(gc->files_win, rf.x, rf.y);
-    resize_window(gc->files_win, rf.w, rf.h);
-  }
-  if (gc->diff_win) {
-    move_window(gc->diff_win, rd.x, rd.y);
-    resize_window(gc->diff_win, rd.w, rd.h);
-  }
-
-  int lw = PANEL_LEFT_W_DEFAULT + PANEL_SPLITTER;
-  int center_w = cr.w - lw - gc->right_w - PANEL_SPLITTER;
-  if (center_w < 20) center_w = 20;
-
-  if (gc->vsplitter_win) {
-    int spl_x = cr.x + lw + center_w;
-    move_window(gc->vsplitter_win, spl_x, cr.y);
-    resize_window(gc->vsplitter_win, PANEL_SPLITTER, cr.h);
-  }
-  if (gc->hsplitter_win) {
-    int spl_x = cr.x + lw;
-    move_window(gc->hsplitter_win, spl_x, cr.y + gc->vsplit_y);
-    resize_window(gc->hsplitter_win, center_w, PANEL_SPLITTER);
-  }
-}
-
-// ============================================================
 // Open / refresh
 // ============================================================
 
@@ -169,40 +96,17 @@ result_t gc_main_proc(window_t *win, uint32_t msg,
       gc = g_gc;
       win->userdata = gc;
 
-      // Form creates toolbar, statusbar, and sidebar automatically.
-      // Look up child windows by generated IDs.
-      gc->branches_win = win->sidebar;
+      // The generated form owns hierarchy, sizing, and database propagation.
+      // The controller only keeps outlets for event routing and refreshes.
+      gc->branches_win = get_window_item(win, ID_MAIN_WINDOW_BRANCHES);
       gc->log_win = get_window_item(win, ID_MAIN_WINDOW_LOG);
       gc->files_win = get_window_item(win, ID_MAIN_WINDOW_FILES);
       gc->diff_win = get_window_item(win, ID_MAIN_WINDOW_DIFF);
-
-      // Set database on tableviews.
-      if (gc->log_win)
-        send_message(gc->log_win, evCreate, 0,
-                     (void *)&main_window_log_tableview_params);
-      if (gc->files_win)
-        send_message(gc->files_win, evCreate, 0,
-                     (void *)&main_window_files_tableview_params);
+      GC_LOG("form outlets: branches=%p log=%p files=%p diff=%p",
+             (void *)gc->branches_win, (void *)gc->log_win,
+             (void *)gc->files_win, (void *)gc->diff_win);
 
       send_message(win, evStatusBar, 0, "No repository");
-
-      // Create splitters.
-      irect16_t cr = get_client_rect(win);
-      int lx = PANEL_LEFT_W_DEFAULT + PANEL_SPLITTER;
-      int center_w = cr.w - lx - gc->right_w - PANEL_SPLITTER;
-
-      gc->vsplitter_win = create_window("",
-          WINDOW_NOTITLE | WINDOW_NOFILL | WINDOW_NOTRAYBUTTON,
-          MAKERECT(lx + center_w, cr.y, PANEL_SPLITTER, cr.h),
-          win, win_splitter, gc->hinstance, (void *)SPLIT_VERT);
-
-      gc->hsplitter_win = create_window("",
-          WINDOW_NOTITLE | WINDOW_NOFILL | WINDOW_NOTRAYBUTTON,
-          MAKERECT(lx, cr.y + gc->vsplit_y, center_w, PANEL_SPLITTER),
-          win, win_splitter, gc->hinstance, (void *)SPLIT_HORZ);
-
-      show_window(gc->vsplitter_win, true);
-      show_window(gc->hsplitter_win, true);
 
       // Load VGA font.
       char font_path[600];
@@ -220,36 +124,7 @@ result_t gc_main_proc(window_t *win, uint32_t msg,
       gc->repo = NULL;
       return false;
 
-    case evResize:
-      if (gc) gc_layout_panels(win);
-      return false;
-
     case evPaint:
-      return false;
-
-    case evMouseMove: {
-      if (!gc || !gc->dragging_splitter) return false;
-      int mx = (int)LOWORD(wparam);
-      int my = (int)HIWORD(wparam);
-      int orient = win_splitter_orientation(gc->dragging_splitter);
-      int delta  = (orient == SPLIT_HORZ)
-                   ? my - gc->drag_start_mouse
-                   : mx - gc->drag_start_mouse;
-      if (orient == SPLIT_VERT)
-        gc->right_w = gc->drag_start_val - delta;
-      else
-        gc->vsplit_y = gc->drag_start_val + delta;
-      gc_layout_panels(win);
-      invalidate_window(win);
-      return true;
-    }
-
-    case evLeftButtonUp:
-      if (gc && gc->dragging_splitter) {
-        gc->dragging_splitter = NULL;
-        set_capture(NULL);
-        return true;
-      }
       return false;
 
     case evCommand: {
@@ -257,27 +132,6 @@ result_t gc_main_proc(window_t *win, uint32_t msg,
 
       if (code == btnClicked || code == 0) {
         gc_handle_command((uint16_t)LOWORD(wparam));
-        return true;
-      }
-
-      if (code == spnDragStart) {
-        if (!gc) return false;
-        uint32_t pos  = (uint32_t)(uintptr_t)lparam;
-        int px = (int)(int16_t)LOWORD(pos);
-        int py = (int)(int16_t)HIWORD(pos);
-        uint16_t spl_id = (uint16_t)LOWORD(wparam);
-        window_t *spl = NULL;
-        if (gc->vsplitter_win && gc->vsplitter_win->id == spl_id)
-          spl = gc->vsplitter_win;
-        else if (gc->hsplitter_win && gc->hsplitter_win->id == spl_id)
-          spl = gc->hsplitter_win;
-        if (!spl) return false;
-        gc->dragging_splitter = spl;
-        int orient = win_splitter_orientation(spl);
-        gc->drag_start_mouse = (orient == SPLIT_HORZ) ? py : px;
-        gc->drag_start_val   = (orient == SPLIT_VERT) ? gc->right_w
-                                                       : gc->vsplit_y;
-        set_capture(win);
         return true;
       }
 

--- a/tools/orionc.c
+++ b/tools/orionc.c
@@ -479,6 +479,12 @@ static void emit_controls_ex(FILE *f, xmlNodePtr parent, const char *form, const
     read_control_attrs(c, &a); control_id(id, sizeof(id), form, a.v[A_NAME], (char *)c->name, ordinal++); ident(klass, sizeof(klass), (char *)c->name, false);
     if (elem(c, "textbox"))
       snprintf(klass, sizeof(klass), "TextEdit");
+    if (elem(c, "stack") || elem(c, "StackView"))
+      snprintf(klass, sizeof(klass), "StackView");
+    if (elem(c, "grid"))
+      snprintf(klass, sizeof(klass), "GridView");
+    if (elem(c, "flow"))
+      snprintf(klass, sizeof(klass), "FlowView");
     if (has_controls(c) && !elem(c, "column")) sz = (rect_t){0};
     rect_attr(c, "padding", &pad) || rect_attr(c, "layout_padding", &pad); rect_attr(c, "margin", &mar) || rect_attr(c, "layout_margin", &mar);
     // Auto-add WINDOW_FLEXSPACE for space and multiedit elements (WPF-style)

--- a/user/message.c
+++ b/user/message.c
@@ -35,14 +35,6 @@ static void free_posted_lparam(uint32_t msg, void *lparam) {
   if (msg == evHttpProgress)
     free(lparam);
 }
-static int sidebar_effective_width(window_t const *win) {
-  if (!win || !win->sidebar) return 0;
-  int w = win->sidebar->layout.layout_fixed_w;
-  if (w <= 0) w = win->sidebar->frame.w;
-  if (w <= 0) w = SIDEBAR_DEFAULT_WIDTH;
-  return w;
-}
-
 // Window hooks
 typedef struct winhook_s {
   winhook_func_t func;
@@ -230,19 +222,6 @@ int send_message(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
         if (win->flags&WINDOW_STATUSBAR) {
           draw_statusbar(win, win->statusbar_text);
         }
-        if ((win->flags & WINDOW_SIDEBAR) && win->sidebar) {
-          // Draw a 1-pixel vertical separator between the sidebar and the content area.
-          // Uses screen-absolute coordinates (set_fullscreen projection is active).
-          int sb_w = sidebar_effective_width(win);
-          if (sb_w <= 0) break;
-          int t_bar = titlebar_height(win);
-          int s_bar = statusbar_height(win);
-          irect16_t sep = {win->frame.x + sb_w,
-                        win->frame.y + t_bar,
-                        1,
-                        win->frame.h - t_bar - s_bar};
-          fill_rect(get_sys_color(brBorderFocus), sep);
-        }
       }
       break;
     case evPaint:
@@ -280,24 +259,6 @@ int send_message(window_t *win, uint32_t msg, uint32_t wparam, void *lparam) {
         }
       }
       break;
-    case sbSetContent: {
-      // Create (or replace) the sidebar child window for a WINDOW_SIDEBAR window.
-      // wparam = desired sidebar width in pixels (0 → use SIDEBAR_DEFAULT_WIDTH).
-      // lparam = winproc_t for the sidebar content window.
-      if (!lparam) break;
-      winproc_t proc = (winproc_t)lparam;
-      int sb_w = (int)wparam > 0 ? (int)wparam : SIDEBAR_DEFAULT_WIDTH;
-      irect16_t cr = get_client_rect(win);
-      win->sidebar = create_window("",
-          WINDOW_NOTITLE | WINDOW_NORESIZE | WINDOW_VSCROLL | WINDOW_NOTRAYBUTTON,
-          MAKERECT(0, 0, sb_w, cr.h),
-          win, proc, win->hinstance, NULL);
-      if (win->sidebar) {
-        win->sidebar->layout.layout_fixed_w = (int16_t)sb_w;
-      }
-      invalidate_window(win);
-      break;
-    }
     case tbSetItems:
     case tbSetStrip:
     case tbSetActiveButton:

--- a/user/messages.h
+++ b/user/messages.h
@@ -147,12 +147,6 @@ enum {
   // HTTP_INVALID_REQUEST indicates an immediate error (bad URL, OOM, etc.).
   evHttpDone,
   evHttpProgress,
-  // Create or replace the sidebar child window for a WINDOW_SIDEBAR window.
-  // wparam = sidebar width in pixels (0 uses SIDEBAR_DEFAULT_WIDTH).
-  // lparam = winproc_t — the window procedure for the sidebar content window.
-  // The framework creates a WINDOW_NOTITLE | WINDOW_NORESIZE | WINDOW_VSCROLL |
-  // WINDOW_NOTRAYBUTTON child at (0, 0) and stores it in win->sidebar.
-  sbSetContent,
 };
 
 // Control notification messages
@@ -246,11 +240,7 @@ typedef struct {
 #define BUTTON_PUSHLIKE     (1 << 13)
 #define BUTTON_AUTORADIO    (1 << 14)
 #define BUTTON_DEFAULT      (1 << 15)
-// A window with WINDOW_SIDEBAR has a fixed-width panel anchored to the left of
-// its client area.  The panel is created via sbSetContent and participates in
-// the normal child-window paint/event dispatch.  A 1-pixel vertical separator
-// is drawn between the sidebar and the content area during evNCPaint.
-#define WINDOW_SIDEBAR      (1 << 16)
+// Bit 16 is intentionally unused (the former WINDOW_SIDEBAR special case).
 #define WINDOW_NOACTIVATE   (1 << 17)  // do not steal keyboard focus when shown
 #define WINDOW_NOTABSTOP    (1 << 18)  // exclude from Tab-key focus cycle (WS_TABSTOP equivalent)
 #define WINDOW_STACK_HORIZONTAL (1 << 19)  // auto-layout stack flows left-to-right
@@ -328,8 +318,6 @@ typedef struct {
 #define TITLEBAR_HEIGHT   (FONT_SIZE + 5)
 #define TOOLBAR_HEIGHT    22
 #define STATUSBAR_HEIGHT  (FONT_SIZE + 5)
-// Default width of a WINDOW_SIDEBAR panel in logical pixels.
-#define SIDEBAR_DEFAULT_WIDTH  180
 #define BUTTON_HEIGHT     19
 #define WINDOW_PADDING 4
 #define LINE_PADDING 5

--- a/user/user.h
+++ b/user/user.h
@@ -469,7 +469,6 @@ struct window_s {
   struct window_s *children;
   struct window_s *parent;
   struct window_s *toolbar; // toolbar host window (win_toolbar); state lives in toolbar->userdata
-  struct window_s *sidebar; // WINDOW_SIDEBAR: the single child that fills the left panel
 };
 
 static inline bool window_has_state(const window_t *win, uint32_t state_flag) {


### PR DESCRIPTION
Closes #187

## Changes

### 1. `tools/orionc.c` — Element→class-name mappings
Added mappings for shorthand container element names to their full registered class names, following the existing `textbox` → `"TextEdit"` pattern:
- `stack` / `StackView` → `"StackView"`
- `grid` → `"GridView"`
- `flow` → `"FlowView"`

Fixes `class 'stack' not found` error because `reg_streq` in `registry.c` requires exact (case-insensitive) string length match (`"stack"` ≠ `"StackView"`).

### 2. `components/gitclient/` (NEW plugin — `gitclient_components`)
- **diff_view.h** — Shared `gc_diff_state_t` type and `GC_DIFF_VIEW_CLASS_NAME` constant
- **diff_view.c** — Window proc `gc_diff_proc` handling `evCreate`/`evDestroy`/`evResize`/`evVScroll`/`evWheel`/`evPaint` (extracted from `view_diff.c`, no `g_gc` dependency)
- **plug.c** — Plugin entry point registering `"DiffView"` class via `GEM_CLASSES`

Replaces the non-existent `"Window"` class (which had no registration) with a proper plugin component, following the same pattern as `imageeditor_components`.

### 3. `examples/gitclient/` — App fixes
- **gitclient.orion** — Changed `<Window>` → `<DiffView>`, added `<plugins>` section
- **view_diff.c** — Kept only `gc_diff_refresh()` (app-side git/db logic), removed window proc
- **gitclient.h** — Added `diff_view.h` include, removed `gc_diff_proc` declaration
- **view_main.c** — Removed duplicate `send_message(evCreate)` calls to tableviews (caused segfault when tableviews finally got created after stack fix — they were already initialized by the form system)
- **main.c** — Loads `gitclient_components` plugin on startup, unloads on shutdown

### 4. Additional bug found
The duplicate `send_message(evCreate)` in `gc_main_proc` crashed because it passed a raw `tableview_params_t*` pointer but the handler expected a `form_ctrl_def_t*` — this was hidden before because the TableView children were never created (due to the stack class not resolving).