### PR TITLE
Add PTY cursor rendering and OSC window title support

### DIFF
--- a/examples/terminal/ansi_parser.c
+++ b/examples/terminal/ansi_parser.c
@@ -34,9 +34,23 @@ void vgat_parser_init(vgat_parser_t *p, const vgat_parser_callbacks_t *cbs) {
   p->erase_display = cbs->erase_display;
   p->erase_line = cbs->erase_line;
   p->cursor_pos = cbs->cursor_pos;
+  p->set_title = cbs->set_title;
   p->cur_fg = VGAT_FG_DEFAULT;
   p->cur_bg = VGAT_BG_DEFAULT;
   p->bold = false;
+}
+
+static void osc_dispatch(vgat_parser_t *p) {
+  p->osc_buf[p->osc_len] = '\0';
+  // Format: Ps ; Pt  — Ps is the parameter, Pt is the payload
+  int ps = 0;
+  char *semi = NULL;
+  for (int i = 0; i < p->osc_len; i++) {
+    if (p->osc_buf[i] == ';') { p->osc_buf[i] = '\0'; semi = &p->osc_buf[i + 1]; break; }
+    ps = ps * 10 + (p->osc_buf[i] - '0');
+  }
+  if ((ps == 0 || ps == 2) && semi && p->set_title)
+    p->set_title(p->userdata, semi);
 }
 
 static void csi_final(vgat_parser_t *p, char final) {
@@ -60,7 +74,10 @@ static void csi_final(vgat_parser_t *p, char final) {
     case 'c':            p->reset(p->screen);           break;
     case 'I':            for (int i = 0; i < VGAT_MAX(1, n >= 1 ? args[0] : 1); i++) p->cursor_right(p->screen); break;
     case 'Z':            for (int i = 0; i < VGAT_MAX(1, n >= 1 ? args[0] : 1); i++) p->cursor_left(p->screen);  break;
-    case 'l': case 'h':  break;  // DECTCEM - ignored
+    case 'l': case 'h':
+      if (p->private_marker == '?' && n >= 1 && args[0] == 25)
+        p->screen->cursor_visible = final == 'h';
+      break;
     case 'd':            break;  // VPA - not implemented
     default:
       break;
@@ -101,8 +118,8 @@ void vgat_parser_feed(vgat_parser_t *p, const uint8_t *data, int len) {
         break;
 
       case VGAT_STATE_ESC:
-        if (c == '[')   { p->state = VGAT_STATE_CSI; p->nparams = 0; p->params[0] = 0; }
-        else if (c == ']')  { p->state = VGAT_STATE_OSC; }
+        if (c == '[')   { p->state = VGAT_STATE_CSI; p->nparams = 0; p->params[0] = 0; p->private_marker = 0; }
+        else if (c == ']')  { p->state = VGAT_STATE_OSC; p->osc_len = 0; }
         else if (c == 'c')  { p->reset(p->screen); p->state = VGAT_STATE_NORMAL; }
         else if (c == '7')  { p->save_cursor(p->screen); p->state = VGAT_STATE_NORMAL; }
         else if (c == '8')  { p->restore_cursor(p->screen); p->state = VGAT_STATE_NORMAL; }
@@ -110,21 +127,23 @@ void vgat_parser_feed(vgat_parser_t *p, const uint8_t *data, int len) {
         break;
 
       case VGAT_STATE_CSI:
-        if (c >= '0' && c <= '9')           { p->params[p->nparams] = p->params[p->nparams] * 10 + (c - '0'); }
-        else if (c == ';')                  { p->nparams++; if (p->nparams < 15) p->params[p->nparams] = 0; }
-        else if (c >= 0x20 && c <= 0x2F)    { /* intermediate bytes */ }
-        else if (c >= 0x3C && c <= 0x3F)    { /* private parameter bytes, e.g. ESC[?25h */ }
-        else if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) { p->nparams++; csi_final(p, (char)c); p->state = VGAT_STATE_NORMAL; }
-        else                                { p->state = VGAT_STATE_NORMAL; }
+        if (c >= '0' && c <= '9') { p->params[p->nparams] = p->params[p->nparams] * 10 + (c - '0'); }
+        else if (c == ';' || c == ':') { if (p->nparams < 15) p->params[++p->nparams] = 0; }
+        else if (c >= '<' && c <= '?') { p->private_marker = (char)c; }
+        else if (c >= 0x20 && c <= 0x2F) { /* CSI intermediate byte */ }
+        else if (c >= 0x40 && c <= 0x7E) { p->nparams++; csi_final(p, (char)c); p->state = VGAT_STATE_NORMAL; }
+        else { p->state = VGAT_STATE_NORMAL; }
         break;
 
       case VGAT_STATE_OSC:
-        if (c == 0x07)      { p->state = VGAT_STATE_NORMAL; }
+        if (c == 0x07)      { osc_dispatch(p); p->state = VGAT_STATE_NORMAL; }
         else if (c == 0x1B) { p->state = VGAT_STATE_OSC_ESC; }
+        else if (p->osc_len < (int)sizeof(p->osc_buf) - 1) { p->osc_buf[p->osc_len++] = (char)c; }
         break;
 
       case VGAT_STATE_OSC_ESC:
-        p->state = (c == '\\') ? VGAT_STATE_NORMAL : VGAT_STATE_OSC;
+        if (c == '\\') { osc_dispatch(p); }
+        p->state = VGAT_STATE_NORMAL;
         break;
     }
   }

--- a/examples/terminal/ansi_parser.h
+++ b/examples/terminal/ansi_parser.h
@@ -27,12 +27,14 @@ typedef struct {
   void (*erase_display)(vgat_screen *s, int mode);
   void (*erase_line)(vgat_screen *s, int mode);
   void (*cursor_pos)(vgat_screen *s, int row, int col);
+  void (*set_title)(void *ud, const char *title);
 } vgat_parser_callbacks_t;
 
 typedef struct vgat_parser_s {
   int state;
   int params[16];
   int nparams;
+  char private_marker;
   int cur_fg;
   int cur_bg;
   bool bold;
@@ -55,6 +57,13 @@ typedef struct vgat_parser_s {
   void (*erase_display)(vgat_screen *s, int mode);
   void (*erase_line)(vgat_screen *s, int mode);
   void (*cursor_pos)(vgat_screen *s, int row, int col);
+  void (*set_title)(void *ud, const char *title);
+
+  // OSC accumulator
+  char osc_buf[256];
+  int  osc_len;
+  bool osc_st_pending; // true after ESC in OSC, waiting for ST
+  void *userdata;      // opaque pointer for callbacks (e.g. window_t*)
 } vgat_parser_t;
 
 void vgat_parser_init(vgat_parser_t *p, const vgat_parser_callbacks_t *cbs);

--- a/examples/terminal/view_main.c
+++ b/examples/terminal/view_main.c
@@ -371,6 +371,13 @@ static void enter_cmd_mode(vgat_state_t *st) {
 
 // ── ANSI parser callbacks ────────────────────────────────────────────────
 
+static void on_set_title(void *ud, const char *title) {
+  window_t *win = (window_t *)ud;
+  if (!win || !title) return;
+  snprintf(win->title, sizeof(win->title), "%s", title);
+  invalidate_window(win);
+}
+
 static void init_ansi_parser(vgat_state_t *st) {
   vgat_parser_init(&st->parser, &(vgat_parser_callbacks_t){
     .screen = &st->screen,
@@ -390,7 +397,9 @@ static void init_ansi_parser(vgat_state_t *st) {
     .erase_display = vgat_screen_erase_display,
     .erase_line = vgat_screen_erase_line,
     .cursor_pos = vgat_screen_cursor_position,
+    .set_title = on_set_title,
   });
+  st->parser.userdata = st->win;
 }
 
 // ── Window procedure ──────────────────────────────────────────────────────
@@ -555,6 +564,19 @@ result_t terminal_proc(window_t *win, uint32_t msg, uint32_t wparam, void *lpara
             int phys = (st->screen.head + st->screen.cursor_row) % st->screen.total_rows;
             vgat_cell *cell = &st->screen.rows[phys * st->screen.cols + csc];
             vga_text_set_cell(&grid, csc, cscr, cell->glyph, cell->bg, cell->fg);
+          }
+        }
+
+        // ── PTY cursor (block cursor via fg/bg flip) ──
+        if (st->mode == VGAT_MODE_PTY && st->cursor_visible &&
+            st->screen.cursor_visible) {
+          int cscr = st->screen.cursor_row - first;
+          int csc = st->screen.cursor_col;
+          if (cscr >= 0 && cscr < content_rows && csc >= 0 && csc < vis_cols &&
+              csc < st->screen.cols) {
+            int phys = (st->screen.head + st->screen.cursor_row) % st->screen.total_rows;
+            vgat_cell *cell = &st->screen.rows[phys * st->screen.cols + csc];
+            vga_text_set_cell(&grid, csc, cscr, cell->ch, cell->bg, cell->fg);
           }
         }
       }


### PR DESCRIPTION
Closes #196

## Changes

### PTY block cursor (view_main.c)
After the cell-copy loop in evPaint, overlay the cursor cell with inverted fg/bg -- same pattern CMD mode already uses. Controlled by existing blink timer and DECTCEM (ESC[?25h/l).

### OSC title parsing (ansi_parser.c/h)
- Add VGAT_STATE_OSC to parser state machine
- Accumulate bytes into 256-byte buffer until BEL (0x07) or ST (ESC backslash)
- Parse Ps parameter: if 0 or 2, call set_title callback with extracted title
- Wire callback in view_main.c to update win->title and invalidate the window

### DECTCEM support (ansi_parser.c)
The ESC[?25h/ESC[?25l sequences now toggle screen->cursor_visible, which the cursor rendering checks before drawing.

### Scope
~30 lines of new code across 3 files. Zero shader changes, zero new textures, zero changes to cell data structure.
