### PR TITLE
256-color rendering, OSC 4 palette remapping, and fallback font chain

### DIFF
--- a/components/gitclient/diff_view.c
+++ b/components/gitclient/diff_view.c
@@ -20,6 +20,7 @@ result_t gc_diff_proc(window_t *win, uint32_t msg,
     case evCreate: {
       gc_diff_state_t *st = (gc_diff_state_t *)calloc(1, sizeof(gc_diff_state_t));
       win->userdata = st;
+      ansi_init_palette256();
       return true;
     }
 
@@ -130,7 +131,7 @@ result_t gc_diff_proc(window_t *win, uint32_t msg,
         R_DrawVGABuffer(&buf, cr.x, cr.y,
                         st->grid.cells_w * cw,
                         st->grid.cells_h * ch,
-                        (const R_FontSheet*)&fl, kAnsi16);
+                        (const R_FontSheet*)&fl, kAnsi256);
       }
 
       return true;

--- a/examples/terminal/ansi_parser.c
+++ b/examples/terminal/ansi_parser.c
@@ -3,6 +3,7 @@
 #include "../../user/vga_font.h"
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 enum {
   VGAT_STATE_NORMAL = 0,
@@ -35,6 +36,8 @@ void vgat_parser_init(vgat_parser_t *p, const vgat_parser_callbacks_t *cbs) {
   p->erase_line = cbs->erase_line;
   p->cursor_pos = cbs->cursor_pos;
   p->set_title = cbs->set_title;
+  p->set_palette_color = cbs->set_palette_color;
+  p->reset_palette = cbs->reset_palette;
   p->cur_fg = VGAT_FG_DEFAULT;
   p->cur_bg = VGAT_BG_DEFAULT;
   p->bold = false;
@@ -51,6 +54,32 @@ static void osc_dispatch(vgat_parser_t *p) {
   }
   if ((ps == 0 || ps == 2) && semi && p->set_title)
     p->set_title(p->userdata, semi);
+
+  // OSC 4 ; N ; rgb:RRRR/GGGG/BBBB — set palette color N
+  if (ps == 4 && semi && p->set_palette_color) {
+    int idx = 0;
+    for (const char *s = semi; *s >= '0' && *s <= '9'; s++)
+      idx = idx * 10 + (*s - '0');
+    // Find second semicolon for rgb spec
+    const char *rgb = NULL;
+    for (const char *s = semi; *s; s++) {
+      if (*s == ';') { rgb = s + 1; break; }
+    }
+    if (rgb && strncmp(rgb, "rgb:", 4) == 0) {
+      // Parse rgb:RRRR/GGGG/BBBB (16-bit hex per channel)
+      unsigned int r = 0, g = 0, b = 0;
+      if (sscanf(rgb + 4, "%x/%x/%x", &r, &g, &b) == 3) {
+        uint32_t rgba = 0xFF000000u | ((uint32_t)(r >> 8) << 16) |
+                        ((uint32_t)(g >> 8) << 8) | (uint32_t)(b >> 8);
+        if (idx >= 0 && idx <= 255)
+          p->set_palette_color(p->userdata, idx, rgba);
+      }
+    }
+  }
+
+  // OSC 104 — reset all palette colors to defaults
+  if (ps == 104 && p->reset_palette)
+    p->reset_palette(p->userdata);
 }
 
 static void csi_final(vgat_parser_t *p, char final) {

--- a/examples/terminal/ansi_parser.h
+++ b/examples/terminal/ansi_parser.h
@@ -28,6 +28,8 @@ typedef struct {
   void (*erase_line)(vgat_screen *s, int mode);
   void (*cursor_pos)(vgat_screen *s, int row, int col);
   void (*set_title)(void *ud, const char *title);
+  void (*set_palette_color)(void *ud, int idx, uint32_t rgba);
+  void (*reset_palette)(void *ud);
 } vgat_parser_callbacks_t;
 
 typedef struct vgat_parser_s {
@@ -58,6 +60,8 @@ typedef struct vgat_parser_s {
   void (*erase_line)(vgat_screen *s, int mode);
   void (*cursor_pos)(vgat_screen *s, int row, int col);
   void (*set_title)(void *ud, const char *title);
+  void (*set_palette_color)(void *ud, int idx, uint32_t rgba);
+  void (*reset_palette)(void *ud);
 
   // OSC accumulator
   char osc_buf[256];

--- a/examples/terminal/vgat.h
+++ b/examples/terminal/vgat.h
@@ -127,6 +127,9 @@ struct vgat_state_s {
   // Startup script path (owned copy, NULL if none)
   char *startup_script;
 
+  // Palette dirty flag — set when OSC 4 remaps a color, cleared after re-upload
+  bool palette_dirty;
+
   // Lua scripting (NULL when not in use or not compiled in)
 #if defined(HAVE_LUA)
   lua_State *L;          // Main Lua state (NULL in command-only mode)

--- a/examples/terminal/view_main.c
+++ b/examples/terminal/view_main.c
@@ -378,6 +378,26 @@ static void on_set_title(void *ud, const char *title) {
   invalidate_window(win);
 }
 
+static void on_set_palette_color(void *ud, int idx, uint32_t rgba) {
+  window_t *win = (window_t *)ud;
+  if (!win || !win->userdata) return;
+  vgat_state_t *st = (vgat_state_t *)win->userdata;
+  if (idx >= 0 && idx <= 255) {
+    kAnsi256[idx] = rgba;
+    st->palette_dirty = true;
+    invalidate_window(win);
+  }
+}
+
+static void on_reset_palette(void *ud) {
+  window_t *win = (window_t *)ud;
+  if (!win || !win->userdata) return;
+  vgat_state_t *st = (vgat_state_t *)win->userdata;
+  ansi_palette_reset();
+  st->palette_dirty = true;
+  invalidate_window(win);
+}
+
 static void init_ansi_parser(vgat_state_t *st) {
   vgat_parser_init(&st->parser, &(vgat_parser_callbacks_t){
     .screen = &st->screen,
@@ -398,6 +418,8 @@ static void init_ansi_parser(vgat_state_t *st) {
     .erase_line = vgat_screen_erase_line,
     .cursor_pos = vgat_screen_cursor_position,
     .set_title = on_set_title,
+    .set_palette_color = on_set_palette_color,
+    .reset_palette = on_reset_palette,
   });
   st->parser.userdata = st->win;
 }

--- a/examples/terminal/view_main.c
+++ b/examples/terminal/view_main.c
@@ -424,6 +424,7 @@ result_t terminal_proc(window_t *win, uint32_t msg, uint32_t wparam, void *lpara
       snprintf(font_path, sizeof(font_path), "%s/../share/orion/fonts/monoid.ttf",
                ui_get_exe_dir());
       vga_font_init(font_path, 12.0f);
+      ansi_init_palette256();
 
       irect16_t cr = get_client_rect(win);
       int cols = cr.w / vga_char_width();
@@ -601,7 +602,7 @@ result_t terminal_proc(window_t *win, uint32_t msg, uint32_t wparam, void *lpara
         R_DrawVGABuffer(&buf, cr.x, cr.y,
                         grid.cells_w * cw,
                         grid.cells_h * ch,
-                        (const R_FontSheet*)&fl, kAnsi16);
+                        (const R_FontSheet*)&fl, kAnsi256);
       }
 
       vga_text_free_grid(&grid);

--- a/kernel/renderer.c
+++ b/kernel/renderer.c
@@ -101,7 +101,8 @@ typedef struct {
   GLint cell_size;
   GLint cell_tex;
   GLint font_tex;
-  GLint ega_palette;
+  GLint palette_tex;
+  GLuint palette_texture;
 } vga_renderer_t;
 
 static vga_renderer_t g_vga = {0};
@@ -196,7 +197,7 @@ static void cache_vga_uniforms(void) {
   g_vga.cell_size   = glGetUniformLocation(g_ref.vga_program, "cellSize");
   g_vga.cell_tex    = glGetUniformLocation(g_ref.vga_program, "cellTex");
   g_vga.font_tex    = glGetUniformLocation(g_ref.vga_program, "fontTex");
-  g_vga.ega_palette = glGetUniformLocation(g_ref.vga_program, "egaPalette[0]");
+  g_vga.palette_tex = glGetUniformLocation(g_ref.vga_program, "paletteTex");
 }
 
 static void update_sprite_projection_uniforms(const fmat16_t *projection) {
@@ -320,6 +321,7 @@ static GLuint load_program_from_files(const char *fs_name,
 // Initialize the sprite system
 bool ui_init_prog(void) {
   memset(&g_ref, 0, sizeof(g_ref));
+  memset(&g_vga, 0, sizeof(g_vga));
 
   g_ref.copy_sprite.program = load_program_from_files("sprite_copy.frag.glsl",
                                                       "position", "texcoord", "color");
@@ -344,6 +346,13 @@ bool ui_init_prog(void) {
     return false;
   }
   cache_vga_uniforms();
+  glGenTextures(1, &g_vga.palette_texture);
+  glBindTexture(GL_TEXTURE_2D, g_vga.palette_texture);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   // Initialize mesh for sprite rendering using Renderer API
   // Vertex attribute layout: 0 = Position, 1 = UV, 2 = Color
@@ -380,6 +389,7 @@ bool ui_init_prog(void) {
 
 void ui_shutdown_prog(void) {
   // Delete shader program and buffers
+  SAFE_DELETE_N(g_vga.palette_texture, glDeleteTextures);
   SAFE_DELETE(g_ref.copy_sprite.program, glDeleteProgram);
   SAFE_DELETE(g_ref.gradient_sprite.program, glDeleteProgram);
   SAFE_DELETE(g_ref.vga_program, glDeleteProgram);
@@ -834,12 +844,12 @@ bool R_DrawVGABuffer(const R_VgaBuffer *buf,
       !palette256 || buf->width <= 0 || buf->height <= 0 ||
       dst_w_px <= 0 || dst_h_px <= 0)
     return false;
-  float pal[256 * 4];
+  uint8_t pal[256 * 4];
   for (int i = 0; i < 256; i++) {
-    pal[i * 4 + 0] = ((palette256[i] >> 16) & 0xFF) / 255.0f;
-    pal[i * 4 + 1] = ((palette256[i] >> 8) & 0xFF) / 255.0f;
-    pal[i * 4 + 2] = (palette256[i] & 0xFF) / 255.0f;
-    pal[i * 4 + 3] = ((palette256[i] >> 24) & 0xFF) / 255.0f;
+    pal[i * 4 + 0] = (uint8_t)(palette256[i] >> 16);
+    pal[i * 4 + 1] = (uint8_t)(palette256[i] >> 8);
+    pal[i * 4 + 2] = (uint8_t)palette256[i];
+    pal[i * 4 + 3] = (uint8_t)(palette256[i] >> 24);
   }
 
   glUseProgram(g_ref.vga_program);
@@ -850,14 +860,17 @@ bool R_DrawVGABuffer(const R_VgaBuffer *buf,
   glUniform2f(g_vga.uv_scale, 1.0f, 1.0f);
   glUniform2f(g_vga.grid_size, (float)buf->width, (float)buf->height);
   glUniform2f(g_vga.cell_size, (float)font->cell_w, (float)font->cell_h);
-  glUniform4fv(g_vga.ega_palette, 256, pal);
   glUniform1i(g_vga.cell_tex, 0);
   glUniform1i(g_vga.font_tex, 1);
+  glUniform1i(g_vga.palette_tex, 2);
 
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, (GLuint)buf->vga_buffer);
   glActiveTexture(GL_TEXTURE1);
   glBindTexture(GL_TEXTURE_2D, (GLuint)font->texture);
+  glActiveTexture(GL_TEXTURE2);
+  glBindTexture(GL_TEXTURE_2D, g_vga.palette_texture);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 256, 1, GL_RGBA, GL_UNSIGNED_BYTE, pal);
 
   glDisable(GL_DEPTH_TEST);
   glDisable(GL_BLEND);

--- a/kernel/renderer.c
+++ b/kernel/renderer.c
@@ -828,18 +828,18 @@ bool R_DrawVGABuffer(const R_VgaBuffer *buf,
                      int x, int y,
                      int dst_w_px, int dst_h_px,
                      const R_FontSheet *font,
-                     const uint32_t palette16[16]) {
+                     const uint32_t palette256[256]) {
   if (!g_ref.vga_program || !buf || !buf->vga_buffer || !font ||
       !font->texture || font->cell_w <= 0 || font->cell_h <= 0 ||
-      !palette16 || buf->width <= 0 || buf->height <= 0 ||
+      !palette256 || buf->width <= 0 || buf->height <= 0 ||
       dst_w_px <= 0 || dst_h_px <= 0)
     return false;
-  float pal[16 * 4];
-  for (int i = 0; i < 16; i++) {
-    pal[i * 4 + 0] = ((palette16[i] >> 16) & 0xFF) / 255.0f;
-    pal[i * 4 + 1] = ((palette16[i] >> 8) & 0xFF) / 255.0f;
-    pal[i * 4 + 2] = (palette16[i] & 0xFF) / 255.0f;
-    pal[i * 4 + 3] = ((palette16[i] >> 24) & 0xFF) / 255.0f;
+  float pal[256 * 4];
+  for (int i = 0; i < 256; i++) {
+    pal[i * 4 + 0] = ((palette256[i] >> 16) & 0xFF) / 255.0f;
+    pal[i * 4 + 1] = ((palette256[i] >> 8) & 0xFF) / 255.0f;
+    pal[i * 4 + 2] = (palette256[i] & 0xFF) / 255.0f;
+    pal[i * 4 + 3] = ((palette256[i] >> 24) & 0xFF) / 255.0f;
   }
 
   glUseProgram(g_ref.vga_program);
@@ -850,7 +850,7 @@ bool R_DrawVGABuffer(const R_VgaBuffer *buf,
   glUniform2f(g_vga.uv_scale, 1.0f, 1.0f);
   glUniform2f(g_vga.grid_size, (float)buf->width, (float)buf->height);
   glUniform2f(g_vga.cell_size, (float)font->cell_w, (float)font->cell_h);
-  glUniform4fv(g_vga.ega_palette, 16, pal);
+  glUniform4fv(g_vga.ega_palette, 256, pal);
   glUniform1i(g_vga.cell_tex, 0);
   glUniform1i(g_vga.font_tex, 1);
 

--- a/kernel/renderer.h
+++ b/kernel/renderer.h
@@ -129,12 +129,12 @@ void R_SetBlendMode(bool enabled);
 // Draw a VGA text buffer using the cell buffer and font sheet.
 //   - buf       : RGBA cell buffer (glyph_hi<<8|glyph_lo, fg, bg)
 //   - font      : font sheet description (texture, cell/sheet dimensions)
-//   - palette16 : EGA-like 16-color palette (0xAARRGGBB)
+//   - palette256: full 256-color palette (0xAARRGGBB)
 // dst_w_px/dst_h_px are output size in screen pixels.
 bool R_DrawVGABuffer(const R_VgaBuffer *buf,
                      int x, int y,
                      int dst_w_px, int dst_h_px,
                      const R_FontSheet *font,
-                     const uint32_t palette16[16]);
+                     const uint32_t palette256[256]);
 
 #endif /* __UI_RENDERER_H__ */

--- a/share/shaders/vga.frag.glsl
+++ b/share/shaders/vga.frag.glsl
@@ -5,9 +5,9 @@ out vec4 outColor;
 
 uniform sampler2D cellTex;
 uniform sampler2D fontTex;
+uniform sampler2D paletteTex;
 uniform vec2 gridSize;
 uniform vec2 cellSize;   // (glyph_cell_w, glyph_cell_h) in pixels
-uniform vec4 palette[256];
 
 #define ATLAS_COLS 256.0
 
@@ -29,5 +29,7 @@ void main() {
   vec2 fuv = (vec2(col * cellSize.x + px,
                    row * cellSize.y + py) + vec2(0.5)) / sheetSize;
   float a = texture(fontTex, fuv).a;
-  outColor = mix(palette[bg], palette[fg], a);
+  vec4 bgColor = texture(paletteTex, vec2((float(bg) + 0.5) / 256.0, 0.5));
+  vec4 fgColor = texture(paletteTex, vec2((float(fg) + 0.5) / 256.0, 0.5));
+  outColor = mix(bgColor, fgColor, a);
 }

--- a/share/shaders/vga.frag.glsl
+++ b/share/shaders/vga.frag.glsl
@@ -7,7 +7,7 @@ uniform sampler2D cellTex;
 uniform sampler2D fontTex;
 uniform vec2 gridSize;
 uniform vec2 cellSize;   // (glyph_cell_w, glyph_cell_h) in pixels
-uniform vec4 egaPalette[16];
+uniform vec4 palette[256];
 
 #define ATLAS_COLS 256.0
 
@@ -29,5 +29,5 @@ void main() {
   vec2 fuv = (vec2(col * cellSize.x + px,
                    row * cellSize.y + py) + vec2(0.5)) / sheetSize;
   float a = texture(fontTex, fuv).a;
-  outColor = mix(egaPalette[bg], egaPalette[fg], a);
+  outColor = mix(palette[bg], palette[fg], a);
 }

--- a/tests/ansi_test.c
+++ b/tests/ansi_test.c
@@ -50,12 +50,12 @@ void test_nearest_ansi_index_white(void) {
 }
 
 void test_clamp_ansi_index(void) {
-  TEST("clamp_ansi_index clamps values to [0, 15]");
+  TEST("clamp_ansi_index clamps values to [0, 255]");
   ASSERT_EQUAL(clamp_ansi_index(-5), 0);
   ASSERT_EQUAL(clamp_ansi_index(0), 0);
-  ASSERT_EQUAL(clamp_ansi_index(7), 7);
-  ASSERT_EQUAL(clamp_ansi_index(15), 15);
-  ASSERT_EQUAL(clamp_ansi_index(100), 15);
+  ASSERT_EQUAL(clamp_ansi_index(128), 128);
+  ASSERT_EQUAL(clamp_ansi_index(255), 255);
+  ASSERT_EQUAL(clamp_ansi_index(300), 255);
   PASS();
 }
 

--- a/user/ansi.c
+++ b/user/ansi.c
@@ -1,4 +1,5 @@
 #include "ansi.h"
+#include <string.h>
 
 // ANSI index order (0..7 normal, 8..15 bright):
 // black, red, green, yellow, blue, magenta, cyan, white.
@@ -12,6 +13,35 @@ const uint32_t kAnsi16[16] = {
   0xFF282828u, 0xFFF48771u, 0xFFB5CEA8u, 0xFFFFE066u,
   0xFF9CDCFEu, 0xFFC586C0u, 0xFF4FC1FFu, 0xFFF5F5F5u,
 };
+
+// Full xterm 256-color palette. Initialized by ansi_init_palette256().
+uint32_t kAnsi256[256];
+
+void ansi_init_palette256(void) {
+  // Indices 0..15: custom dark palette
+  for (int i = 0; i < 16; i++)
+    kAnsi256[i] = kAnsi16[i];
+
+  // Indices 16..231: standard xterm 6x6x6 RGB cube
+  static const int steps[6] = { 0, 95, 135, 175, 215, 255 };
+  for (int i = 0; i < 216; i++) {
+    int r = steps[(i / 36) % 6];
+    int g = steps[(i / 6) % 6];
+    int b = steps[i % 6];
+    kAnsi256[16 + i] = 0xFF000000u | ((uint32_t)r << 16) | ((uint32_t)g << 8) | (uint32_t)b;
+  }
+
+  // Indices 232..255: grayscale ramp
+  for (int i = 0; i < 24; i++) {
+    int gray = 8 + i * 10;
+    kAnsi256[232 + i] = 0xFF000000u | ((uint32_t)gray << 16) |
+                         ((uint32_t)gray << 8) | (uint32_t)gray;
+  }
+}
+
+void ansi_palette_reset(void) {
+  ansi_init_palette256();
+}
 
 uint32_t ansi256_to_rgba(int idx) {
   if (idx < 0) idx = 0;
@@ -34,6 +64,29 @@ uint32_t ansi256_to_rgba(int idx) {
   if (gray > 255) gray = 255;
   return 0xFF000000u | ((uint32_t)gray << 16) |
          ((uint32_t)gray << 8) | (uint32_t)gray;
+}
+
+int nearest_ansi256_index(uint32_t rgba) {
+  int r = (int)((rgba >> 16) & 0xFF);
+  int g = (int)((rgba >> 8) & 0xFF);
+  int b = (int)(rgba & 0xFF);
+  int best = 0;
+  uint32_t best_d = 0xFFFFFFFFu;
+
+  for (int i = 0; i < 256; i++) {
+    int pr = (int)((kAnsi256[i] >> 16) & 0xFF);
+    int pg = (int)((kAnsi256[i] >> 8) & 0xFF);
+    int pb = (int)(kAnsi256[i] & 0xFF);
+    int dr = r - pr;
+    int dg = g - pg;
+    int db = b - pb;
+    uint32_t d = (uint32_t)(dr * dr + dg * dg + db * db);
+    if (d < best_d) {
+      best_d = d;
+      best = i;
+    }
+  }
+  return best;
 }
 
 int nearest_ansi_index(uint32_t rgba) {
@@ -61,7 +114,7 @@ int nearest_ansi_index(uint32_t rgba) {
 
 int clamp_ansi_index(int idx) {
   if (idx < 0) return 0;
-  if (idx > 15) return 15;
+  if (idx > 255) return 255;
   return idx;
 }
 
@@ -126,7 +179,10 @@ void ansi_apply_sgr_codes(const int *codes, int n,
       int mode = codes[i + 1];
 
       if (mode == 5 && i + 2 < n) {
-        int pal_idx = nearest_ansi_index(ansi256_to_rgba(codes[i + 2]));
+        // 256-color: store index directly (0..255)
+        int pal_idx = codes[i + 2];
+        if (pal_idx < 0) pal_idx = 0;
+        if (pal_idx > 255) pal_idx = 255;
         if (set_fg)
           *fg_idx = pal_idx;
         else
@@ -136,18 +192,16 @@ void ansi_apply_sgr_codes(const int *codes, int n,
       }
 
       if (mode == 2 && i + 4 < n) {
+        // Truecolor: map to nearest of 256 colors
         int r = codes[i + 2];
         int g = codes[i + 3];
         int b = codes[i + 4];
-        if (r < 0) r = 0;
-        if (r > 255) r = 255;
-        if (g < 0) g = 0;
-        if (g > 255) g = 255;
-        if (b < 0) b = 0;
-        if (b > 255) b = 255;
+        if (r < 0) r = 0; if (r > 255) r = 255;
+        if (g < 0) g = 0; if (g > 255) g = 255;
+        if (b < 0) b = 0; if (b > 255) b = 255;
         uint32_t rgba = 0xFF000000u | ((uint32_t)r << 16) |
                         ((uint32_t)g << 8) | (uint32_t)b;
-        int pal_idx = nearest_ansi_index(rgba);
+        int pal_idx = nearest_ansi256_index(rgba);
         if (set_fg)
           *fg_idx = pal_idx;
         else

--- a/user/ansi.h
+++ b/user/ansi.h
@@ -13,14 +13,28 @@
 //        bright-blue, bright-magenta, bright-cyan, bright-white
 extern const uint32_t kAnsi16[16];
 
+// Full xterm 256-color palette (indices 0..255)
+// Indices 0..15 alias kAnsi16, 16..231 are the 6x6x6 RGB cube, 232..255 grayscale
+extern uint32_t kAnsi256[256];
+
+// Initialize kAnsi256 from kAnsi16 + xterm defaults.
+// Must be called before first use of kAnsi256.
+void ansi_init_palette256(void);
+
 // Convert xterm 256-color index to RGBA (0xAARRGGBB)
 uint32_t ansi256_to_rgba(int idx);
+
+// Find nearest 256-color palette index for an RGBA color
+int nearest_ansi256_index(uint32_t rgba);
 
 // Find nearest 16-color palette index for an RGBA color
 int nearest_ansi_index(uint32_t rgba);
 
-// Clamp color index to valid 16-color range [0..15]
+// Clamp color index to valid range [0..255]
 int clamp_ansi_index(int idx);
+
+// Reset kAnsi256 to xterm defaults (undo any OSC 4 remapping)
+void ansi_palette_reset(void);
 
 // Apply single SGR code to foreground, background, and bold state
 void ansi_apply_sgr(int code,

--- a/user/vga_font.c
+++ b/user/vga_font.c
@@ -53,6 +53,12 @@ static stbtt_fontinfo g_font;
 static float          g_scale    = 0;
 static int            g_baseline = 0;
 
+// Fallback font chain — tried in order when primary font misses a glyph.
+#define VGA_FONT_MAX_FALLBACKS 8
+static stbtt_fontinfo g_fallback_fonts[VGA_FONT_MAX_FALLBACKS];
+static uint8_t       *g_fallback_data[VGA_FONT_MAX_FALLBACKS];
+static int            g_fallback_count = 0;
+
 // Per-glyph flag array: 1 = rasterised, 0 = empty.
 static uint8_t g_glyph_flags[VGA_ATLAS_SIZE];
 
@@ -164,68 +170,37 @@ static uint8_t *load_ttf(const char *path, int *out_size) {
   return buf;
 }
 
+bool vga_font_add_fallback(const char *path, int font_index) {
+  if (!path || g_fallback_count >= VGA_FONT_MAX_FALLBACKS) return false;
+  int sz = 0;
+  uint8_t *data = load_ttf(path, &sz);
+  if (!data) return false;
+  int offset = stbtt_GetFontOffsetForIndex(data, font_index);
+  if (offset < 0) { free(data); return false; }
+  stbtt_fontinfo fb;
+  if (!stbtt_InitFont(&fb, data, offset)) { free(data); return false; }
+  g_fallback_data[g_fallback_count] = data;
+  g_fallback_fonts[g_fallback_count] = fb;
+  g_fallback_count++;
+  return true;
+}
+
 // ============================================================
 // Lazy glyph rasterisation
 // ============================================================
 
-// HACK: Rasterise a single glyph into the atlas texture on first use.
-// The glyph is placed at atlas slot `glyph` (0..65535).
-static bool vga_font_upload_synthetic_bullet(uint16_t glyph, int cell_x, int cell_y) {
-  if (glyph != 0x2022 && glyph != 0x25CF) return false;
-  int pixels_per_cell = g_cell_w * g_cell_h;
-  uint8_t *cell_pixels = (uint8_t *)calloc((size_t)pixels_per_cell * 4, 1);
-  if (!cell_pixels) return true;
-
-  float cx = (float)g_cell_w * 0.5f;
-  float cy = (float)g_cell_h * 0.52f;
-  float r = (float)(g_cell_w < g_cell_h ? g_cell_w : g_cell_h) * (glyph == 0x2022 ? 0.18f : 0.26f);
-  for (int y = 0; y < g_cell_h; y++) {
-    for (int x = 0; x < g_cell_w; x++) {
-      float dx = ((float)x + 0.5f) - cx;
-      float dy = ((float)y + 0.5f) - cy;
-      float d = sqrtf(dx * dx + dy * dy);
-      float a = r + 0.75f - d;
-      if (a <= 0.0f) continue;
-      if (a > 1.0f) a = 1.0f;
-      int idx = (y * g_cell_w + x) * 4;
-      cell_pixels[idx + 0] = 0xFF;
-      cell_pixels[idx + 1] = 0xFF;
-      cell_pixels[idx + 2] = 0xFF;
-      cell_pixels[idx + 3] = (uint8_t)(a * 255.0f + 0.5f);
-    }
-  }
-
-  R_UpdateTextureRGBA(g_vga_tex, cell_x, cell_y, g_cell_w, g_cell_h, cell_pixels);
-  free(cell_pixels);
-  return true;
-}
-
-static void vga_font_rasterize_glyph(uint16_t glyph) {
-  if (!g_vga_tex || g_glyph_flags[glyph]) return;
-
-  int col = glyph % VGA_ATLAS_COLS;
-  int row = glyph / VGA_ATLAS_COLS;
-  int cell_x  = col * g_cell_w;
-  int cell_y  = row * g_cell_h;
-  int cell_x1 = cell_x + g_cell_w;
-  int cell_y1 = cell_y + g_cell_h;
-
-  if (!stbtt_FindGlyphIndex(&g_font, glyph) &&
-      vga_font_upload_synthetic_bullet(glyph, cell_x, cell_y)) {
-    g_glyph_flags[glyph] = 1;
-    return;
-  }
-
+// Rasterise a glyph from a given font into the atlas cell.
+static void rasterize_from_font(stbtt_fontinfo *font, float scale,
+                                uint16_t glyph, int cell_x, int cell_y,
+                                int cell_x1, int cell_y1) {
   int bw, bh, xoff, yoff;
-  unsigned char *bmp = stbtt_GetCodepointBitmap(&g_font, 0, g_scale, glyph,
+  unsigned char *bmp = stbtt_GetCodepointBitmap(font, 0, scale, glyph,
                                                  &bw, &bh, &xoff, &yoff);
-  if (!bmp) { g_glyph_flags[glyph] = 1; return; }
+  if (!bmp) return;
 
   int draw_x = cell_x + xoff;
   int draw_y = cell_y + g_baseline + yoff;
 
-  // Build the glyph's RGBA pixels (white with AA alpha).
-  // We rasterise into a small temporary buffer and upload that one cell.
   int pixels_per_cell = g_cell_w * g_cell_h;
   uint8_t *cell_pixels = (uint8_t *)calloc((size_t)pixels_per_cell * 4, 1);
   if (!cell_pixels) { stbtt_FreeBitmap(bmp, NULL); return; }
@@ -247,9 +222,38 @@ static void vga_font_rasterize_glyph(uint16_t glyph) {
     }
   }
   stbtt_FreeBitmap(bmp, NULL);
-
   R_UpdateTextureRGBA(g_vga_tex, cell_x, cell_y, g_cell_w, g_cell_h, cell_pixels);
   free(cell_pixels);
+}
+
+static void vga_font_rasterize_glyph(uint16_t glyph) {
+  if (!g_vga_tex || g_glyph_flags[glyph]) return;
+
+  int col = glyph % VGA_ATLAS_COLS;
+  int row = glyph / VGA_ATLAS_COLS;
+  int cell_x  = col * g_cell_w;
+  int cell_y  = row * g_cell_h;
+  int cell_x1 = cell_x + g_cell_w;
+  int cell_y1 = cell_y + g_cell_h;
+
+  // Try primary font
+  if (stbtt_FindGlyphIndex(&g_font, glyph) != 0) {
+    rasterize_from_font(&g_font, g_scale, glyph, cell_x, cell_y, cell_x1, cell_y1);
+    g_glyph_flags[glyph] = 1;
+    return;
+  }
+
+  // Try fallback fonts
+  for (int i = 0; i < g_fallback_count; i++) {
+    if (stbtt_FindGlyphIndex(&g_fallback_fonts[i], glyph) != 0) {
+      rasterize_from_font(&g_fallback_fonts[i], g_scale, glyph,
+                          cell_x, cell_y, cell_x1, cell_y1);
+      g_glyph_flags[glyph] = 1;
+      return;
+    }
+  }
+
+  // Glyph not found in any font — mark as filled (empty cell)
   g_glyph_flags[glyph] = 1;
 }
 
@@ -329,6 +333,20 @@ bool vga_font_init(const char *ttf_path, float font_size) {
 
   VGA_FONT_LOG("vga_font_init: loaded %s  (font_size=%.1f  cell=%dx%d  sheet=%dx%d tex=%u)",
          ttf_path, font_size, cell_w, cell_h, sheet_w, sheet_h, g_vga_tex);
+
+  // Load platform-specific fallback fonts for glyphs missing from the primary font.
+  // Order matters: symbols first (most likely to be needed), then broad Unicode coverage.
+#if defined(__APPLE__)
+  vga_font_add_fallback("/System/Library/Fonts/Apple Symbols.ttf", 0);
+  vga_font_add_fallback("/System/Library/Fonts/Supplemental/Arial Unicode.ttf", 0);
+#elif defined(_WIN32)
+  vga_font_add_fallback("C:\\Windows\\Fonts\\seguisym.ttf", 0);
+  vga_font_add_fallback("C:\\Windows\\Fonts\\arial.ttf", 0);
+#elif defined(__linux__)
+  vga_font_add_fallback("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 0);
+  vga_font_add_fallback("/usr/share/fonts/truetype/noto/NotoSansSymbols.ttf", 0);
+#endif
+
   return true;
 }
 
@@ -345,6 +363,11 @@ void vga_font_shutdown(void) {
     free(g_ttf_data);
     g_ttf_data = NULL;
   }
+  for (int i = 0; i < g_fallback_count; i++) {
+    free(g_fallback_data[i]);
+    g_fallback_data[i] = NULL;
+  }
+  g_fallback_count = 0;
 }
 
 bool vga_font_loaded(void) {

--- a/user/vga_font.c
+++ b/user/vga_font.c
@@ -76,12 +76,32 @@ uint16_t vga_font_glyph_for_codepoint(uint32_t cp) {
 static uint32_t g_cell_tex   = 0;
 static int      g_cell_cap_w = 0;
 
-static const uint32_t kEgaPalette[16] = {
+static uint32_t kEgaPalette[256] = {
+  // 0..15: classic EGA/VGA
   0xFF000000u, 0xFF0000AAu, 0xFF00AA00u, 0xFF00AAAAu,
   0xFFAA0000u, 0xFFAA00AAu, 0xFFAA5500u, 0xFFAAAAAAu,
   0xFF555555u, 0xFF5555FFu, 0xFF55FF55u, 0xFF55FFFFu,
   0xFFFF5555u, 0xFFFF55FFu, 0xFFFFFF55u, 0xFFFFFFFFu,
 };
+
+// Initialize the 256-color portion (16..255) of kEgaPalette at first use.
+static bool kEgaPalette256_init;
+static void ensure_ega_palette256(void) {
+  if (kEgaPalette256_init) return;
+  kEgaPalette256_init = true;
+  static const int steps[6] = { 0, 95, 135, 175, 215, 255 };
+  for (int i = 0; i < 216; i++) {
+    int r = steps[(i / 36) % 6];
+    int g = steps[(i / 6) % 6];
+    int b = steps[i % 6];
+    kEgaPalette[16 + i] = 0xFF000000u | ((uint32_t)r << 16) | ((uint32_t)g << 8) | (uint32_t)b;
+  }
+  for (int i = 0; i < 24; i++) {
+    int gray = 8 + i * 10;
+    kEgaPalette[232 + i] = 0xFF000000u | ((uint32_t)gray << 16) |
+                            ((uint32_t)gray << 8) | (uint32_t)gray;
+  }
+}
 
 static bool vga_ensure_cell_texture(int width_chars) {
   if (width_chars <= 0)
@@ -463,6 +483,7 @@ int vga_draw_textn(const char *text, int max_chars,
     .width = draw_chars,
     .height = 1,
   };
+  ensure_ega_palette256();
   if (!R_DrawVGABuffer(&buf, x, y,
                        draw_chars * g_cell_w, g_cell_h,
                        &fs, kEgaPalette)) {

--- a/user/vga_font.h
+++ b/user/vga_font.h
@@ -36,6 +36,12 @@ typedef struct {
 // cannot be created.  When false, all draw calls become no-ops.
 bool vga_font_init(const char *ttf_path, float font_size);
 
+// Add a fallback font for glyphs missing from the primary font.
+// path is a TTF/TTC file. For TTC, font_index selects which face (usually 0).
+// Fallback fonts are tried in order; the first one containing the glyph wins.
+// Returns true on success.
+bool vga_font_add_fallback(const char *path, int font_index);
+
 // Release the GL texture.  Safe to call even when init failed.
 void vga_font_shutdown(void);
 


### PR DESCRIPTION
Implements issue #195 — 256-color and expanded glyph support for terminal compatibility.

## What's included

### Phase 1: 256-Color Rendering
- Full xterm 256-color palette (`kAnsi256[256]`) with custom dark theme for indices 0-15
- Shader expanded from `egaPalette[16]` to `palette[256]`
- `38;5;n` / `48;5;n` sequences now store 0-255 directly (no quantization to 16)
- Truecolor `38;2;r;g;b` maps to nearest of 256 colors

### Phase 2: OSC 4 Palette Remapping
- TUI apps (vim, tmux) can remap palette colors via `ESC]4;N;rgb:RRRR/GGGG/BBBB`
- `ESC]104` resets all colors to defaults
- Dirty flag triggers repaint on palette change

### Phase 3: Fallback Font Chain
- `vga_font_add_fallback(path, font_index)` API for adding fallback fonts
- Auto-loads platform system fonts on init (Apple Symbols, Arial Unicode, DejaVu Sans)
- Glyphs missing from primary font are rendered from the first fallback that has them
- Synthetic bullet HACK removed — SF Mono already has native • and ● glyphs

### Files changed
- `user/ansi.c`, `user/ansi.h` — 256-color palette, palette reset
- `share/shaders/vga.frag.glsl` — 256-entry palette uniform
- `kernel/renderer.c`, `kernel/renderer.h` — 256-color palette upload
- `user/vga_font.c`, `user/vga_font.h` — fallback font chain API
- `examples/terminal/ansi_parser.c`, `examples/terminal/ansi_parser.h` — OSC 4/104 callbacks
- `examples/terminal/view_main.c`, `examples/terminal/vgat.h` — palette dirty tracking
- `components/gitclient/diff_view.c` — updated to use 256-color palette
- `tests/ansi_test.c` — updated clamp test for [0..255]