### PR TITLE
gitclient: add clone and remote management dialogs (Phase 1)

### DIFF
--- a/examples/gitclient/controller.c
+++ b/examples/gitclient/controller.c
@@ -278,6 +278,62 @@ bool gc_discard_all(void) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Clone
+// ═══════════════════════════════════════════════════════════════════════════
+
+bool gc_clone_repo(const char *url, const char *path) {
+  gc_state_t *gc = g_gc;
+  if (!gc || !gc->repo || !url || !url[0] || !path || !path[0]) return false;
+  const char *args[] = { "git", "clone", url, path, NULL };
+  char buf[4096] = {0};
+  if (!git_run_sync(gc->repo, args, buf, sizeof(buf))) {
+    GC_LOG("gc_clone_repo failed: %s", buf);
+    return false;
+  }
+  return true;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Remote management
+// ═══════════════════════════════════════════════════════════════════════════
+
+bool gc_add_remote(const char *name, const char *url) {
+  gc_state_t *gc = g_gc;
+  if (!gc || !gc->repo || !name || !name[0] || !url || !url[0]) return false;
+  char buf[1024] = {0};
+  const char *args[] = { "git", "remote", "add", name, url, NULL };
+  if (!git_run_sync(gc->repo, args, buf, sizeof(buf))) {
+    GC_LOG("gc_add_remote failed: %s", buf);
+    return false;
+  }
+  return true;
+}
+
+bool gc_remove_remote(const char *name) {
+  gc_state_t *gc = g_gc;
+  if (!gc || !gc->repo || !name || !name[0]) return false;
+  char buf[1024] = {0};
+  const char *args[] = { "git", "remote", "remove", name, NULL };
+  if (!git_run_sync(gc->repo, args, buf, sizeof(buf))) {
+    GC_LOG("gc_remove_remote failed: %s", buf);
+    return false;
+  }
+  return true;
+}
+
+bool gc_set_remote_url(const char *name, const char *url) {
+  gc_state_t *gc = g_gc;
+  if (!gc || !gc->repo || !name || !name[0] || !url || !url[0]) return false;
+  char buf[1024] = {0};
+  const char *args[] = { "git", "remote", "set-url", name, url, NULL };
+  if (!git_run_sync(gc->repo, args, buf, sizeof(buf))) {
+    GC_LOG("gc_set_remote_url failed: %s", buf);
+    return false;
+  }
+  return true;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Stash
 // ═══════════════════════════════════════════════════════════════════════════
 

--- a/examples/gitclient/git_backend.c
+++ b/examples/gitclient/git_backend.c
@@ -452,6 +452,19 @@ int git_get_remotes(git_repo_t *repo, char (*out)[256], int max) {
 }
 
 // ============================================================
+// Public: remote URL
+// ============================================================
+
+bool git_get_remote_url(git_repo_t *repo, const char *name, char *buf, int buf_sz) {
+  if (!repo || !name || !name[0] || !buf || buf_sz <= 0) return false;
+  const char *args[] = { "git", "remote", "get-url", name, NULL };
+  if (!git_run_sync(repo, args, buf, buf_sz)) return false;
+  char *nl = strchr(buf, '\n');
+  if (nl) *nl = '\0';
+  return true;
+}
+
+// ============================================================
 // Async thread
 // TODO(platform-C): git_run_async() should be replaced by
 // axRunCommandAsync(cmd, op, notify_win, post_msg_id) once the platform

--- a/examples/gitclient/gitclient.h
+++ b/examples/gitclient/gitclient.h
@@ -122,6 +122,8 @@ typedef struct git_repo_s git_repo_t;
 #define gc_main_window_form          gitclient_main_window_form
 #define gc_commit_dialog_form        gitclient_commit_dialog_form
 #define gc_new_branch_dialog_form    gitclient_new_branch_dialog_form
+#define gc_clone_dialog_form         gitclient_clone_dialog_form
+#define gc_remote_dialog_form        gitclient_remote_dialog_form
 #define gc_push_pull_dialog_form     gitclient_push_pull_dialog_form
 #define gc_branch_rename_dialog_form gitclient_branch_rename_dialog_form
 #define gc_database_schema           gitclient_database_schema
@@ -152,6 +154,8 @@ typedef struct {
 
   int          selected_commit;
   int          selected_file;
+
+  char         clone_path[512];
 
   // UI windows
   window_t    *main_win;
@@ -190,6 +194,10 @@ bool gc_rebase_onto(const char *branch);
 bool gc_rename_branch(const char *old_name, const char *new_name);
 bool gc_discard_file(const char *path);
 bool gc_discard_all(void);
+bool gc_clone_repo(const char *url, const char *path);
+bool gc_add_remote(const char *name, const char *url);
+bool gc_remove_remote(const char *name);
+bool gc_set_remote_url(const char *name, const char *url);
 void gc_stash(void);
 void gc_stash_pop(void);
 
@@ -211,6 +219,7 @@ bool git_get_diff(git_repo_t *repo, const char *path,
 int  git_get_branches(git_repo_t *repo, git_branch_t *out, int max);
 bool git_current_branch(git_repo_t *repo, char *buf, int buf_sz);
 int  git_get_remotes(git_repo_t *repo, char (*out)[256], int max);
+bool git_get_remote_url(git_repo_t *repo, const char *name, char *buf, int buf_sz);
 
 bool git_run_async(git_repo_t *repo, git_op_t op,
                    const char *args[],
@@ -254,6 +263,8 @@ bool gc_show_commit_dialog(window_t *parent, bool amend);
 bool gc_show_new_branch_dialog(window_t *parent);
 bool gc_show_rename_branch_dialog(window_t *parent, const char *cur_name);
 void gc_show_push_pull_dialog(window_t *parent, git_op_t op);
+void gc_show_clone_dialog(window_t *parent);
+void gc_show_remote_dialog(window_t *parent);
 void gc_show_about_dialog(window_t *parent);
 
 #endif // __GITCLIENT_H__

--- a/examples/gitclient/gitclient.orion
+++ b/examples/gitclient/gitclient.orion
@@ -199,6 +199,55 @@
             </stack>
         </form>
 
+        <form name="clone_dialog"
+              title="Clone Repository"
+              width="420"
+              auto_layout="1"
+              spacing="6"
+              padding="8">
+            <stack orientation="horizontal" spacing="6">
+                <label text="URL:" />
+                <textedit name="url" flags="flexspace" />
+            </stack>
+            <stack orientation="horizontal" spacing="6">
+                <label text="Path:" />
+                <textedit name="path" flags="flexspace" />
+                <button name="browse" text="..." />
+            </stack>
+            <label name="status" text="" />
+            <stack orientation="horizontal" spacing="6">
+                <space />
+                <button name="ok" text="Clone" flags="default" />
+                <button name="cancel" text="Cancel" />
+            </stack>
+        </form>
+
+        <form name="remote_dialog"
+              title="Manage Remotes"
+              width="400"
+              height="320"
+              auto_layout="1"
+              spacing="6"
+              padding="8">
+            <label text="Remotes:" />
+            <combobox name="remote_list" flags="flexspace" />
+            <stack orientation="horizontal" spacing="6">
+                <label text="Name:" />
+                <textedit name="name" flags="flexspace" />
+            </stack>
+            <stack orientation="horizontal" spacing="6">
+                <label text="URL:" />
+                <textedit name="url" flags="flexspace" />
+            </stack>
+            <stack orientation="horizontal" spacing="6">
+                <button name="add" text="Add" />
+                <button name="update" text="Update" />
+                <button name="remove" text="Remove" />
+                <space />
+                <button name="close" text="Close" flags="default" />
+            </stack>
+        </form>
+
         <form name="push_pull_dialog"
               title="Remote Operation"
               width="262"

--- a/examples/gitclient/view_clone_dlg.c
+++ b/examples/gitclient/view_clone_dlg.c
@@ -1,0 +1,68 @@
+// Clone repository dialog — uses generated form from gitclient.orion.
+
+#include "gitclient.h"
+
+static result_t clone_dlg_proc(window_t *win, uint32_t msg,
+                                uint32_t wparam, void *lparam) {
+  switch (msg) {
+    case evCreate:
+      win->userdata = lparam;
+      return true;
+
+    case evCommand:
+      if (HIWORD(wparam) == btnClicked) {
+        window_t *src = (window_t *)lparam;
+        if (!src) return false;
+        if (src->id == ID_CLONE_DIALOG_CANCEL) {
+          end_dialog(win, 0);
+          return true;
+        }
+        if (src->id == ID_CLONE_DIALOG_BROWSE) {
+          char path[512] = {0};
+          openfilename_t ofn = {0};
+          ofn.lStructSize = sizeof(ofn);
+          ofn.lpstrFile   = path;
+          ofn.nMaxFile    = sizeof(path);
+          ofn.Flags       = OFN_PICKFOLDER;
+          if (get_folder_name(&ofn))
+            set_window_item_text(win, ID_CLONE_DIALOG_PATH, "%s", path);
+          return true;
+        }
+        if (src->id == ID_CLONE_DIALOG_OK) {
+          gc_state_t *gc = g_gc;
+          if (!gc) { end_dialog(win, 0); return true; }
+
+          char url[512] = {0};
+          char path[512] = {0};
+          send_message(get_window_item(win, ID_CLONE_DIALOG_URL),
+                       edGetText, sizeof(url), url);
+          send_message(get_window_item(win, ID_CLONE_DIALOG_PATH),
+                       edGetText, sizeof(path), path);
+
+          if (!url[0]) {
+            message_box(win, "Please enter a repository URL.", "Clone", MB_OK);
+            return true;
+          }
+          if (!path[0]) {
+            message_box(win, "Please select a destination path.", "Clone", MB_OK);
+            return true;
+          }
+
+          strncpy(gc->clone_path, path, sizeof(gc->clone_path) - 1);
+          const char *args[] = { "git", "clone", url, path, NULL };
+          git_run_async(gc->repo, GIT_OP_CLONE, args, gc->main_win);
+          end_dialog(win, 1);
+          return true;
+        }
+      }
+      return false;
+
+    default:
+      return false;
+  }
+}
+
+void gc_show_clone_dialog(window_t *parent) {
+  show_dialog_from_form(&gc_clone_dialog_form, "Clone Repository", parent,
+                         clone_dlg_proc, NULL);
+}

--- a/examples/gitclient/view_main.c
+++ b/examples/gitclient/view_main.c
@@ -220,10 +220,16 @@ result_t gc_main_proc(window_t *win, uint32_t msg,
     case evGitOpDone: {
       git_async_result_t *res = (git_async_result_t *)lparam;
       if (res) {
-        if (!res->success)
+        if (!res->success) {
           message_box(win, res->output, "Operation failed", MB_OK);
-        else
+        } else if (res->op == GIT_OP_CLONE) {
+          gc_state_t *gc_ = g_gc;
+          if (gc_ && gc_->clone_path[0])
+            gc_open_repo(gc_->clone_path);
+          gc_->clone_path[0] = '\0';
+        } else {
           gc_refresh_all();
+        }
         git_async_result_free(res);
       }
       return true;

--- a/examples/gitclient/view_menubar.c
+++ b/examples/gitclient/view_menubar.c
@@ -97,6 +97,8 @@ void gc_handle_command(uint16_t id) {
       break;
     }
     case ID_FILE_CLONE:
+      if (gc->main_win)
+        gc_show_clone_dialog(gc->main_win);
       break;
     case ID_FILE_QUIT:
       ui_request_quit();
@@ -224,6 +226,8 @@ void gc_handle_command(uint16_t id) {
         gc_show_push_pull_dialog(gc->main_win, GIT_OP_PUSH);
       break;
     case ID_REMOTE_MANAGE:
+      if (gc->main_win)
+        gc_show_remote_dialog(gc->main_win);
       break;
 
     case ID_HELP_ABOUT:

--- a/examples/gitclient/view_remote_dlg.c
+++ b/examples/gitclient/view_remote_dlg.c
@@ -1,0 +1,126 @@
+// Remote management dialog — uses generated form from gitclient.orion.
+
+#include "gitclient.h"
+
+static void refresh_remote_list(window_t *win) {
+  gc_state_t *gc = g_gc;
+  if (!gc || !gc->repo) return;
+  window_t *cb = get_window_item(win, ID_REMOTE_DIALOG_REMOTE_LIST);
+  send_message(cb, cbClear, 0, NULL);
+  char remotes[8][256];
+  int n = git_get_remotes(gc->repo, remotes, 8);
+  for (int i = 0; i < n; i++)
+    send_message(cb, cbAddString, 0, remotes[i]);
+}
+
+static void populate_fields_from_selection(window_t *win) {
+  gc_state_t *gc = g_gc;
+  if (!gc || !gc->repo) return;
+  window_t *cb = get_window_item(win, ID_REMOTE_DIALOG_REMOTE_LIST);
+  char name[256] = {0};
+  send_message(cb, edGetText, sizeof(name), name);
+  if (!name[0]) return;
+  set_window_item_text(win, ID_REMOTE_DIALOG_NAME, "%s", name);
+  char url[512] = {0};
+  git_get_remote_url(gc->repo, name, url, sizeof(url));
+  set_window_item_text(win, ID_REMOTE_DIALOG_URL, "%s", url);
+}
+
+static result_t remote_dlg_proc(window_t *win, uint32_t msg,
+                                 uint32_t wparam, void *lparam) {
+  switch (msg) {
+    case evCreate:
+      win->userdata = lparam;
+      refresh_remote_list(win);
+      return true;
+
+    case evCommand: {
+      uint16_t code = HIWORD(wparam);
+      if (code == cbSelectionChange) {
+        window_t *src = (window_t *)lparam;
+        if (src && src->id == ID_REMOTE_DIALOG_REMOTE_LIST) {
+          populate_fields_from_selection(win);
+          return true;
+        }
+        return false;
+      }
+      if (code == btnClicked) {
+        window_t *src = (window_t *)lparam;
+        if (!src) return false;
+
+        if (src->id == ID_REMOTE_DIALOG_CLOSE) {
+          end_dialog(win, 0);
+          return true;
+        }
+
+        gc_state_t *gc = g_gc;
+        if (!gc || !gc->repo) return true;
+
+        if (src->id == ID_REMOTE_DIALOG_ADD) {
+          char name[256] = {0};
+          char url[512] = {0};
+          send_message(get_window_item(win, ID_REMOTE_DIALOG_NAME),
+                       edGetText, sizeof(name), name);
+          send_message(get_window_item(win, ID_REMOTE_DIALOG_URL),
+                       edGetText, sizeof(url), url);
+          if (!name[0] || !url[0]) {
+            message_box(win, "Please enter both name and URL.", "Add Remote", MB_OK);
+            return true;
+          }
+          if (!gc_add_remote(name, url))
+            message_box(win, "Failed to add remote.", "Add Remote", MB_OK);
+          refresh_remote_list(win);
+          return true;
+        }
+
+        if (src->id == ID_REMOTE_DIALOG_UPDATE) {
+          char name[256] = {0};
+          char url[512] = {0};
+          send_message(get_window_item(win, ID_REMOTE_DIALOG_NAME),
+                       edGetText, sizeof(name), name);
+          send_message(get_window_item(win, ID_REMOTE_DIALOG_URL),
+                       edGetText, sizeof(url), url);
+          if (!name[0]) {
+            message_box(win, "Please enter the remote name.", "Update Remote", MB_OK);
+            return true;
+          }
+          if (!url[0]) {
+            message_box(win, "Please enter the remote URL.", "Update Remote", MB_OK);
+            return true;
+          }
+          if (!gc_set_remote_url(name, url))
+            message_box(win, "Failed to update remote.", "Update Remote", MB_OK);
+          refresh_remote_list(win);
+          return true;
+        }
+
+        if (src->id == ID_REMOTE_DIALOG_REMOVE) {
+          char name[256] = {0};
+          send_message(get_window_item(win, ID_REMOTE_DIALOG_NAME),
+                       edGetText, sizeof(name), name);
+          if (!name[0]) {
+            message_box(win, "Please enter the remote name.", "Remove Remote", MB_OK);
+            return true;
+          }
+          char msg[320];
+          snprintf(msg, sizeof(msg), "Remove remote \"%s\"?", name);
+          if (message_box(win, msg, "Remove Remote", MB_YESNO) != IDYES)
+            return true;
+          if (!gc_remove_remote(name))
+            message_box(win, "Failed to remove remote.", "Remove Remote", MB_OK);
+          refresh_remote_list(win);
+          return true;
+        }
+      }
+      return false;
+    }
+
+    default:
+      return false;
+  }
+}
+
+void gc_show_remote_dialog(window_t *parent) {
+  show_dialog_from_form(&gc_remote_dialog_form, "Manage Remotes", parent,
+                         remote_dlg_proc, NULL);
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 (Clone + Remotes) from https://github.com/corepunch/orion-ui/issues/201.

### Changes

**gitclient.orion** — Added two forms:
- `clone_dialog`: URL text edit, path text edit + browse button, Clone/Cancel
- `remote_dialog`: remote list (combobox), name+URL text edits, Add/Update/Remove buttons

**controller.c** — 4 new functions following existing `git_run_sync` pattern:
- `gc_clone_repo(url, path)` — `git clone <url> <path>`
- `gc_add_remote(name, url)` — `git remote add <name> <url>`
- `gc_remove_remote(name)` — `git remote remove <name>`
- `gc_set_remote_url(name, url)` — `git remote set-url <name> <url>`

**git_backend.c**:
- `git_get_remote_url(repo, name, buf, buf_sz)` — `git remote get-url <name>`

**view_clone_dlg.c** (new) — Clone dialog with async execution:
- Validates non-empty URL and path
- Starts clone via `git_run_async(GIT_OP_CLONE, ...)`
- Stores destination in `gc->clone_path` for post-clone handling

**view_remote_dlg.c** (new) — Remote management dialog:
- Populates combobox from `git_get_remotes()`
- Selection auto-fills name/URL fields via `git_get_remote_url()`
- Add, Update (set-url), Remove with confirmation

**view_main.c**:
- `evGitOpDone`: on `GIT_OP_CLONE` success, opens cloned repo via `gc_open_repo()`

**view_menubar.c**:
- `ID_FILE_CLONE` now opens clone dialog (was empty)
- `ID_REMOTE_MANAGE` now opens remote management dialog (was empty)